### PR TITLE
Update ai-platform-docs CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,7 +91,6 @@
 /samples/python/foundry-local/tutorial-tool-calling/src/app.py @microsoft-foundry/AI-Platform-Docs
 /samples/python/foundry-local/tutorial-voice-to-text/src/app.py @microsoft-foundry/AI-Platform-Docs
 /samples/python/foundry-local/web-server/src/app.py @microsoft-foundry/AI-Platform-Docs
-/samples/python/foundry-models/model-router/model-router-chat-completions-observability.py @microsoft-foundry/AI-Platform-Docs
 /samples/python/foundry-models/model-router/model-router-chat-completions.py @microsoft-foundry/AI-Platform-Docs
 /samples/python/foundry-models/model-router/model-router-foundry-responses.py @microsoft-foundry/AI-Platform-Docs
 /samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py @microsoft-foundry/AI-Platform-Docs


### PR DESCRIPTION
Automated CODEOWNERS refresh from code-ref-monitor outputs.

Source file: CODEOWNERS-foundry-samples.txt
Entries added: 0
Entries removed: 1

This update replaces only */ai-platform-docs-owned entries and preserves all other CODEOWNERS lines.