### PR TITLE
Fix endpoint format comment and stray quote in quickstart samples

### DIFF
--- a/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
+++ b/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
@@ -5,7 +5,7 @@ using OpenAI.Responses;
 
 #pragma warning disable OPENAI001
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 var ProjectEndpoint = "your_project_endpoint";
 var AgentName = "your_agent_name";
 

--- a/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
+++ b/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
@@ -3,7 +3,7 @@ using Azure.AI.Projects;
 using Azure.AI.Projects.Agents;
 using Azure.AI.Extensions.OpenAI;
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 var ProjectEndpoint = "your_project_endpoint";
 var AgentName = "your_agent_name";
 

--- a/samples/csharp/quickstart/responses/quickstart-responses.cs
+++ b/samples/csharp/quickstart/responses/quickstart-responses.cs
@@ -5,7 +5,7 @@ using OpenAI.Responses;
 
 #pragma warning disable OPENAI001
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 var projectEndpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT") ?? "your_project_endpoint";
 var modelDeployment = Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT") ?? "gpt-5-mini";
 

--- a/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
+++ b/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
@@ -8,7 +8,7 @@ import com.openai.models.responses.ResponseCreateParams;
 
 public class ChatWithAgent {
     public static void main(String[] args) {
-        // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+        // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
         String ProjectEndpoint = "your_project_endpoint";
         String AgentName = "your_agent_name";
         

--- a/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
+++ b/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
@@ -6,7 +6,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 
 public class CreateAgent {
     public static void main(String[] args) {
-        // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+        // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
         String ProjectEndpoint = "your_project_endpoint";
         String AgentName = "your_agent_name";
 

--- a/samples/java/quickstart/responses/src/main/java/com/azure/ai/agents/CreateResponse.java
+++ b/samples/java/quickstart/responses/src/main/java/com/azure/ai/agents/CreateResponse.java
@@ -6,7 +6,7 @@ import com.openai.models.responses.ResponseCreateParams;
 
 public class CreateResponse {
     public static void main(String[] args) {
-        // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+        // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
         String ProjectEndpoint = "your_project_endpoint";
 
         // Create responses client to call Foundry API

--- a/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
+++ b/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
@@ -1,7 +1,7 @@
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 
-# Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+# Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 PROJECT_ENDPOINT = "your_project_endpoint"
 AGENT_NAME = "your_agent_name"
 

--- a/samples/python/quickstart/create-agent/quickstart-create-agent.py
+++ b/samples/python/quickstart/create-agent/quickstart-create-agent.py
@@ -2,7 +2,7 @@ from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import PromptAgentDefinition
 
-# Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+# Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 PROJECT_ENDPOINT = "your_project_endpoint"
 AGENT_NAME = "your_agent_name"
 
@@ -16,7 +16,7 @@ project = AIProjectClient(
 agent = project.agents.create_version(
     agent_name=AGENT_NAME,
     definition=PromptAgentDefinition(
-        model="gpt-5-mini",  # supports all Foundry direct models"
+        model="gpt-5-mini",  # supports all Foundry direct models
         instructions="You are a helpful assistant that answers general questions",
     ),
 )

--- a/samples/python/quickstart/responses/quickstart-responses.py
+++ b/samples/python/quickstart/responses/quickstart-responses.py
@@ -3,7 +3,7 @@ import os
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 
-# Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+# Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 PROJECT_ENDPOINT = os.getenv("AZURE_AI_PROJECT_ENDPOINT", "your_project_endpoint")
 MODEL_DEPLOYMENT = os.getenv("MODEL_DEPLOYMENT", "gpt-5-mini")
 

--- a/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
+++ b/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
@@ -1,7 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 const PROJECT_ENDPOINT = "your_project_endpoint";
 const AGENT_NAME = "your_agent_name";
 

--- a/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
+++ b/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
@@ -1,7 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 const PROJECT_ENDPOINT = "your_project_endpoint";
 const AGENT_NAME = "your_agent_name";
 

--- a/samples/typescript/quickstart/responses/src/quickstart-responses.ts
+++ b/samples/typescript/quickstart/responses/src/quickstart-responses.ts
@@ -1,7 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
-// Format: "https://resource_name.ai.azure.com/api/projects/project_name"
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 const PROJECT_ENDPOINT = "your_project_endpoint";
 
 async function main(): Promise<void> {


### PR DESCRIPTION
The endpoint format comment omits the `.services` subdomain. The actual project endpoint is https://<resource-name>.services.ai.azure.com/api/projects/<project-name>, so anyone following the comment builds an unreachable URL. Corrected across the Python, C#, TypeScript, and Java quickstart samples.

Also removes a stray trailing double quote from a comment in quickstart-create-agent.py.

Found while running the Foundry quickstart end to end for a docs freshness review.