### PR TITLE
Add validation dashboard for daily sample runs

### DIFF
--- a/.github/scripts/collect-artifact-links.py
+++ b/.github/scripts/collect-artifact-links.py
@@ -19,14 +19,15 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
-SAMPLE_ARTIFACT_PATTERN = re.compile(r"^validation-pilot-(?!manifest$|run-\d+-\d+$)(.+)$")
+ARTIFACT_NAME_PREFIX = "validation-pilot-"
 
 
-def collect_links(lines: list[str], repository: str, run_id: str) -> dict[str, str]:
+def collect_links(
+    lines: list[str], repository: str, run_id: str, reserved_names: set[str]
+) -> dict[str, str]:
     links: dict[str, str] = {}
     for line in lines:
         line = line.strip()
@@ -42,10 +43,9 @@ def collect_links(lines: list[str], repository: str, run_id: str) -> dict[str, s
         artifact_id = artifact.get("id")
         if not isinstance(name, str) or not isinstance(artifact_id, int):
             continue
-        match = SAMPLE_ARTIFACT_PATTERN.match(name)
-        if not match:
+        if name in reserved_names or not name.startswith(ARTIFACT_NAME_PREFIX):
             continue
-        sample_id = match.group(1)
+        sample_id = name[len(ARTIFACT_NAME_PREFIX):]
         links[sample_id] = f"https://github.com/{repository}/actions/runs/{run_id}/artifacts/{artifact_id}"
     return links
 
@@ -55,11 +55,16 @@ def main() -> int:
     parser.add_argument("--artifacts-file", type=Path, required=True, help="NDJSON of {name, id} artifact objects")
     parser.add_argument("--repository", required=True, help="owner/repo, used to build the artifact page URL")
     parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", required=True, help="Used to exclude this workflow's own combined-run artifact by its exact name")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
+    reserved_names = {
+        "validation-pilot-manifest",
+        f"validation-pilot-run-{args.run_id}-{args.run_attempt}",
+    }
     try:
         lines = args.artifacts_file.read_text(encoding="utf-8").splitlines()
-        links = collect_links(lines, args.repository, args.run_id)
+        links = collect_links(lines, args.repository, args.run_id, reserved_names)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(links, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     except OSError as exc:

--- a/.github/scripts/collect-artifact-links.py
+++ b/.github/scripts/collect-artifact-links.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Map each per-sample validation-pilot artifact in a workflow run to its sample id.
+
+render-validation-dashboard.py links an Artifact column per row to the exact
+artifact (validation-pilot-{sample_id}, uploaded by the build-readiness/
+live-service job for that sample) containing that sample's sample-result.json
+and diagnostics.log -- so a reader can download the full diagnostic log
+without needing repo write access to browse job logs.
+
+Input is NDJSON (one artifact object per line) with at least `name` and `id`
+fields, e.g. produced by:
+  gh api repos/OWNER/REPO/actions/runs/RUN_ID/artifacts --paginate -q '.artifacts[] | {name, id}'
+
+Artifacts that aren't a per-sample result (the combined manifest artifact, or
+the combined run artifact this very script's output feeds into) are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SAMPLE_ARTIFACT_PATTERN = re.compile(r"^validation-pilot-(?!manifest$|run-\d+-\d+$)(.+)$")
+
+
+def collect_links(lines: list[str], repository: str, run_id: str) -> dict[str, str]:
+    links: dict[str, str] = {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            artifact = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(artifact, dict):
+            continue
+        name = artifact.get("name")
+        artifact_id = artifact.get("id")
+        if not isinstance(name, str) or not isinstance(artifact_id, int):
+            continue
+        match = SAMPLE_ARTIFACT_PATTERN.match(name)
+        if not match:
+            continue
+        sample_id = match.group(1)
+        links[sample_id] = f"https://github.com/{repository}/actions/runs/{run_id}/artifacts/{artifact_id}"
+    return links
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts-file", type=Path, required=True, help="NDJSON of {name, id} artifact objects")
+    parser.add_argument("--repository", required=True, help="owner/repo, used to build the artifact page URL")
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        lines = args.artifacts_file.read_text(encoding="utf-8").splitlines()
+        links = collect_links(lines, args.repository, args.run_id)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(links, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"collect-artifact-links: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/collect-job-links.py
+++ b/.github/scripts/collect-job-links.py
@@ -12,6 +12,9 @@ Matrix job display names GitHub Actions generates look like:
 GitHub truncates the display name to roughly 100 characters, but the sample
 id -- the matrix's first field -- always appears in full before the first
 comma, so it can be recovered even when the rest of the name is cut off.
+This depends on sample ids never containing a comma or parenthesis;
+discover-validation-samples.py enforces a `[A-Za-z0-9_-]+` id alphabet at
+discovery time specifically so that guarantee holds here.
 
 Input is NDJSON (one job object per line) with at least `name` and
 `html_url` fields, e.g. produced by:

--- a/.github/scripts/collect-job-links.py
+++ b/.github/scripts/collect-job-links.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Map each matrixed validation-pilot job in a workflow run to its sample id.
+
+render-validation-dashboard.py links every row's Status badge to the exact
+job that produced it (where the failing step is visible), rather than the
+generic run-overview page. This script builds that sample-id -> job-URL
+mapping from the run's job list.
+
+Matrix job display names GitHub Actions generates look like:
+  "build-readiness (sample-id, samples/.../path, language, shape)"
+  "live-service (sample-id, samples/.../path, language, shape)"
+GitHub truncates the display name to roughly 100 characters, but the sample
+id -- the matrix's first field -- always appears in full before the first
+comma, so it can be recovered even when the rest of the name is cut off.
+
+Input is NDJSON (one job object per line) with at least `name` and
+`html_url` fields, e.g. produced by:
+  gh api repos/OWNER/REPO/actions/runs/RUN_ID/jobs --paginate -q '.jobs[] | {name, html_url}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+JOB_NAME_PATTERN = re.compile(r"^(?:build-readiness|live-service) \(([^,()]+),")
+
+
+def collect_links(lines: list[str]) -> dict[str, str]:
+    links: dict[str, str] = {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            job = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(job, dict):
+            continue
+        name = job.get("name")
+        html_url = job.get("html_url")
+        if not isinstance(name, str) or not isinstance(html_url, str):
+            continue
+        match = JOB_NAME_PATTERN.match(name)
+        if not match:
+            continue
+        sample_id = match.group(1).strip()
+        if sample_id:
+            links[sample_id] = html_url
+    return links
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jobs-file", type=Path, required=True, help="NDJSON of {name, html_url} job objects")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        lines = args.jobs_file.read_text(encoding="utf-8").splitlines()
+        links = collect_links(lines)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(links, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"collect-job-links: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/discover-validation-samples.py
+++ b/.github/scripts/discover-validation-samples.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import stat
 from pathlib import Path
 
@@ -19,12 +20,41 @@ SUPPORTED_LANGUAGES = {
 }
 
 
+SAMPLE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+RESERVED_SAMPLE_IDS = {"manifest"}
+RESERVED_SAMPLE_ID_PATTERN = re.compile(r"^run-\d+-\d+$")
+
+
 class DiscoveryError(ValueError):
     """A sample metadata error that should stop discovery."""
 
 
 def sample_id(path: str) -> str:
     return path.removeprefix("samples/").replace("/", "-")
+
+
+def validate_sample_id(identifier: str, path: str) -> None:
+    """Reject IDs that would be unsafe or ambiguous downstream.
+
+    Consumers embed a sample's derived ID directly in artifact names
+    (``validation-pilot-{id}``) and in GitHub Actions matrix job display
+    names (parsed as the first comma-separated field, e.g.
+    ``build-readiness ({id}, ...)``). An ID containing a comma or
+    parenthesis would break that parsing, and an ID equal to "manifest" or
+    matching "run-<digits>-<digits>" would collide with this workflow's own
+    reserved artifact names (``validation-pilot-manifest``,
+    ``validation-pilot-run-{run_id}-{run_attempt}``).
+    """
+    if not SAMPLE_ID_PATTERN.fullmatch(identifier):
+        raise DiscoveryError(
+            f"{path}: derived sample ID '{identifier}' must contain only "
+            "letters, digits, '-', and '_'"
+        )
+    if identifier in RESERVED_SAMPLE_IDS or RESERVED_SAMPLE_ID_PATTERN.fullmatch(identifier):
+        raise DiscoveryError(
+            f"{path}: derived sample ID '{identifier}' collides with a reserved "
+            "validation-pilot artifact name"
+        )
 
 
 def metadata_path(root: Path, metadata: Path) -> str:
@@ -75,6 +105,7 @@ def discover(root: Path) -> dict:
         validate_metadata_file(root, metadata)
         path = metadata.parent.relative_to(root).as_posix()
         identifier = sample_id(path)
+        validate_sample_id(identifier, path)
         if identifier in paths_by_id:
             raise DiscoveryError(
                 f"{metadata_path(root, metadata)}: duplicate derived sample ID "

--- a/.github/scripts/render-fallback-dashboard.py
+++ b/.github/scripts/render-fallback-dashboard.py
@@ -42,9 +42,10 @@ def render(run_url: str | None) -> str:
 <body>
 <h1>foundry-samples validation dashboard</h1>
 <div class="banner">
-  &#9888;&#65039; The most recent run's results could not be retrieved (the
-  combined result artifact was missing or failed to download), so this page
-  could not be regenerated. Open the {link} for what happened.
+  &#9888;&#65039; The most recent run's results could not be retrieved or parsed
+  (the combined result artifact was missing, failed to download, or contained
+  malformed validation data), so this page could not be regenerated. Open the
+  {link} for what happened.
 </div>
 </body>
 </html>

--- a/.github/scripts/render-fallback-dashboard.py
+++ b/.github/scripts/render-fallback-dashboard.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Render a minimal fallback page for the validation dashboard.
+
+Used by the publish-dashboard job in validation-pilot.yml when the combined
+run-result artifact could not be downloaded (for example, because the
+discovery or completeness job crashed before uploading it). In that case
+render-validation-dashboard.py has nothing to render from, but the Pages
+deployment must still run -- otherwise whatever was deployed by a previous,
+unrelated run would keep looking like the current status. This page makes
+the failure visible instead of silently leaving a stale dashboard live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+from pathlib import Path
+
+
+def esc(value: str) -> str:
+    return html.escape(value, quote=True)
+
+
+def render(run_url: str | None) -> str:
+    link = (
+        f'<a href="{esc(run_url)}">workflow run</a>'
+        if run_url
+        else "workflow run"
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>foundry-samples validation dashboard</title>
+<style>
+  body {{ background: #ffffff; color: #1b1f23; margin: 0; padding: 2rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
+  .banner {{ padding: 0.75rem 1rem; border-radius: 6px; margin: 1rem 0; background: #ffebe9; border: 1px solid #cf222e; color: #82071e; }}
+  a {{ color: #0969da; }}
+</style>
+</head>
+<body>
+<h1>foundry-samples validation dashboard</h1>
+<div class="banner">
+  &#9888;&#65039; The most recent run's results could not be retrieved (the
+  combined result artifact was missing or failed to download), so this page
+  could not be regenerated. Open the {link} for what happened.
+</div>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--run-url")
+    args = parser.parse_args()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render(args.run_url), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -256,7 +256,9 @@ SORT_SCRIPT = """
   var currentIndex = null;
   var currentDir = 1;
   headers.forEach(function (th) {
-    th.addEventListener("click", function () {
+    var button = th.querySelector(".sort-button");
+    if (!button) return;
+    button.addEventListener("click", function () {
       var index = parseInt(th.getAttribute("data-sort-index"), 10);
       var type = th.getAttribute("data-sort-type") || "text";
       currentDir = index === currentIndex ? -currentDir : 1;
@@ -275,8 +277,13 @@ SORT_SCRIPT = """
         return 0;
       });
       rows.forEach(function (row) { tbody.appendChild(row); });
-      headers.forEach(function (other) { other.removeAttribute("data-sort-dir"); });
-      th.setAttribute("data-sort-dir", currentDir === 1 ? "asc" : "desc");
+      headers.forEach(function (other) {
+        other.removeAttribute("data-sort-dir");
+        other.setAttribute("aria-sort", "none");
+      });
+      var dir = currentDir === 1 ? "asc" : "desc";
+      th.setAttribute("data-sort-dir", dir);
+      th.setAttribute("aria-sort", dir === "asc" ? "ascending" : "descending");
     });
   });
 })();
@@ -437,7 +444,8 @@ def render(
         ("Codeowner", "text"),
     ]
     header_cells = "".join(
-        f'<th data-sort-index="{index}" data-sort-type="{sort_type}">{esc(label)}<span class="sort-indicator"></span></th>'
+        f'<th data-sort-index="{index}" data-sort-type="{sort_type}" aria-sort="none">'
+        f'<button type="button" class="sort-button">{esc(label)}<span class="sort-indicator"></span></button></th>'
         for index, (label, sort_type) in enumerate(columns)
     )
     table = (
@@ -476,8 +484,14 @@ def render(
   .banner-incomplete {{ background: #fff8c5; border: 1px solid #d4a72c; color: #6b5900; }}
   table {{ border-collapse: collapse; width: 100%; background: #ffffff; margin-top: 1.5rem; }}
   th, td {{ text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #d0d7de; font-size: 0.9rem; }}
-  th {{ background: #f6f8fa; color: #1b1f23; cursor: pointer; user-select: none; white-space: nowrap; }}
-  th:hover {{ background: #eaeef2; }}
+  th {{ background: #f6f8fa; color: #1b1f23; white-space: nowrap; padding: 0; }}
+  .sort-button {{
+    all: unset; display: block; box-sizing: border-box; width: 100%;
+    padding: 0.5rem 0.75rem; cursor: pointer; user-select: none;
+    font: inherit; color: inherit;
+  }}
+  .sort-button:hover {{ background: #eaeef2; }}
+  .sort-button:focus-visible {{ outline: 2px solid #0969da; outline-offset: -2px; }}
   th .sort-indicator::after {{ content: ""; margin-left: 0.35rem; color: #57606a; }}
   th[data-sort-dir="asc"] .sort-indicator::after {{ content: "▲"; }}
   th[data-sort-dir="desc"] .sort-indicator::after {{ content: "▼"; }}

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -193,7 +193,12 @@ def load_link_map(path: Path | None, repository: str | None, url_suffix_pattern:
     (or the whole map) is silently dropped and the caller falls back to a
     less specific link.
     """
-    if not path or not path.is_file() or not repository or not REPOSITORY_PATTERN.fullmatch(repository):
+    if (
+        not path
+        or not path.is_file()
+        or not isinstance(repository, str)
+        or not REPOSITORY_PATTERN.fullmatch(repository)
+    ):
         return {}
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
@@ -222,7 +227,7 @@ def load_codeowners(path: Path | None) -> list[tuple[str, str]]:
         return []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
+    except (OSError, UnicodeError):
         return []
     entries: list[tuple[str, str]] = []
     for line in lines:

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -260,8 +260,8 @@ def codeowners_for(sample_path: str, codeowners: list[tuple[str, str]]) -> list[
             primary_owners = pattern_owners
         elif pattern_dir.startswith(sample_path + "/"):
             nested_owner_tokens.extend(pattern_owners.split())
-    tokens: list[str] = list(primary_owners.split()) if primary_owners else []
-    for token in nested_owner_tokens:
+    tokens: list[str] = []
+    for token in (primary_owners.split() if primary_owners else []) + nested_owner_tokens:
         if token not in tokens:
             tokens.append(token)
     return tokens
@@ -454,7 +454,7 @@ def render(
     if not complete:
         status_lines.append(
             '<div class="banner banner-incomplete">'
-            "⚠️ The most recent scheduled run reported an <strong>incomplete</strong> result set. "
+            "⚠️ The most recent validation run reported an <strong>incomplete</strong> result set. "
             "This snapshot is not authoritative fleet status — open the workflow run linked below "
             "for the details that could not be normalized here."
             "</div>"

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -387,6 +387,14 @@ FILTER_SCRIPT = """
   var summary = document.getElementById("filter-summary");
   var total = rows.length;
 
+  function syncPressedState(buttons, activeButton) {
+    buttons.forEach(function (button) {
+      var isActive = button === activeButton;
+      button.classList.toggle("active", isActive);
+      button.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+  }
+
   function matches(row, group) {
     if (group.active === "all") return true;
     var value = row.getAttribute("data-" + group.data) || "";
@@ -421,11 +429,15 @@ FILTER_SCRIPT = """
 
   groups.forEach(function (group) {
     var buttons = group.bar.querySelectorAll("button[" + group.attr + "]");
+    if (!buttons.length) return;
+    var initialButton = group.bar.querySelector("button[" + group.attr + "].active") || buttons[0];
+    var initialValue = initialButton.getAttribute(group.attr);
+    group.active = initialValue === null ? "all" : initialValue;
+    syncPressedState(buttons, initialButton);
     buttons.forEach(function (button) {
       button.addEventListener("click", function () {
         group.active = button.getAttribute(group.attr);
-        buttons.forEach(function (other) { other.classList.remove("active"); });
-        button.classList.add("active");
+        syncPressedState(buttons, button);
         applyFilters();
       });
     });
@@ -471,10 +483,12 @@ def render(
     status_lines.append(f'<p class="meta">{" · ".join(meta_bits)}</p>')
 
     filter_sections = []
-    filter_buttons = [f'<button type="button" data-filter-outcome="all" class="active">All ({len(records)})</button>']
+    filter_buttons = [
+        f'<button type="button" data-filter-outcome="all" class="active" aria-pressed="true">All ({len(records)})</button>'
+    ]
     for outcome in ("passed", "sample failure", "infrastructure/error", "skipped/not-completed"):
         filter_buttons.append(
-            f'<button type="button" data-filter-outcome="{esc(outcome)}" class="filter-btn {OUTCOME_CSS_CLASS.get(outcome, "")}">'
+            f'<button type="button" data-filter-outcome="{esc(outcome)}" class="filter-btn {OUTCOME_CSS_CLASS.get(outcome, "")}" aria-pressed="false">'
             f"{esc(OUTCOMES[outcome])} ({counts[outcome]})</button>"
         )
     filter_sections.append(
@@ -485,10 +499,12 @@ def render(
     for record in records:
         language = record["sample"]["language"]
         language_counts[language] = language_counts.get(language, 0) + 1
-    language_buttons = [f'<button type="button" data-filter-language="all" class="active">All ({len(records)})</button>']
+    language_buttons = [
+        f'<button type="button" data-filter-language="all" class="active" aria-pressed="true">All ({len(records)})</button>'
+    ]
     for language in sorted(language_counts, key=str.lower):
         language_buttons.append(
-            f'<button type="button" data-filter-language="{esc(language.lower())}" class="filter-btn">'
+            f'<button type="button" data-filter-language="{esc(language.lower())}" class="filter-btn" aria-pressed="false">'
             f"{esc(language)} ({language_counts[language]})</button>"
         )
     filter_sections.append(
@@ -502,10 +518,12 @@ def render(
         key = str(stage).lower()
         validation_counts[key] = validation_counts.get(key, 0) + 1
         validation_labels[key] = stage_label(stage)
-    validation_buttons = [f'<button type="button" data-filter-validation="all" class="active">All ({len(records)})</button>']
+    validation_buttons = [
+        f'<button type="button" data-filter-validation="all" class="active" aria-pressed="true">All ({len(records)})</button>'
+    ]
     for key in sorted(validation_counts, key=lambda value: validation_labels[value].lower()):
         validation_buttons.append(
-            f'<button type="button" data-filter-validation="{esc(key)}" class="filter-btn">'
+            f'<button type="button" data-filter-validation="{esc(key)}" class="filter-btn" aria-pressed="false">'
             f"{esc(validation_labels[key])} ({validation_counts[key]})</button>"
         )
     filter_sections.append(
@@ -524,15 +542,17 @@ def render(
             continue
         for owner in owners:
             codeowner_counts[owner] = codeowner_counts.get(owner, 0) + 1
-    codeowner_buttons = [f'<button type="button" data-filter-codeowner="all" class="active">All ({len(records)})</button>']
+    codeowner_buttons = [
+        f'<button type="button" data-filter-codeowner="all" class="active" aria-pressed="true">All ({len(records)})</button>'
+    ]
     for owner in sorted(codeowner_counts, key=str.lower):
         codeowner_buttons.append(
-            f'<button type="button" data-filter-codeowner="{esc(owner.lower())}" class="filter-btn">'
+            f'<button type="button" data-filter-codeowner="{esc(owner.lower())}" class="filter-btn" aria-pressed="false">'
             f"{esc(codeowner_display_name(owner))} ({codeowner_counts[owner]})</button>"
         )
     if unowned_count:
         codeowner_buttons.append(
-            f'<button type="button" data-filter-codeowner="" class="filter-btn">Unowned ({unowned_count})</button>'
+            f'<button type="button" data-filter-codeowner="" class="filter-btn" aria-pressed="false">Unowned ({unowned_count})</button>'
         )
     filter_sections.append(
         f'<div class="filter-group"><strong>Codeowner</strong><div id="codeowner-filters" class="filters">{"".join(codeowner_buttons)}</div></div>'

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Render a static, durable HTML dashboard from validation-pilot result artifacts.
+
+Unlike render-validation-report.py (a run-scoped Markdown summary written to
+the GitHub Actions job summary, which disappears once you leave that run),
+this renders a single self-contained index.html snapshot meant to be published
+somewhere durable (GitHub Pages) so "what is the current status of every
+sample" has one stable URL that always reflects the most recent completed
+run.
+
+Every discovered sample (from the manifest, which discovery regenerates by
+globbing samples/**/sample.yaml on each run) gets exactly one row, so newly
+added samples appear automatically the next time the workflow runs -- no
+changes needed here or in the workflow.
+
+Security posture for a page that will be public and crawlable:
+  - No diagnostic/error text is rendered, only structured fields (outcome,
+    stage, duration, completion time). Full diagnostics stay behind the
+    existing workflow run / artifact, which is where investigation belongs.
+  - Every value is HTML-escaped; links are only ever built from the same
+    validated repository/sha pattern render-validation-report.py already
+    uses (see validation_pilot_common.sample_url).
+  - The only inline script is a small, static, self-contained click-to-sort
+    handler. It never interpolates result data into the script itself --
+    all row data flows through escaped `data-sort-value` attributes read at
+    runtime, so nothing from a sample/result value is ever executed as code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from validation_pilot_common import (
+    OUTCOMES,
+    REPOSITORY_PATTERN,
+    SHA_PATTERN,
+    ContractError,
+    collect,
+    load_expected,
+    sample_url,
+)
+
+# Severity-style ordering used both for the default row order and as the
+# numeric sort value for the Status column (lower = needs more attention).
+OUTCOME_RANK = {
+    "sample failure": 0,
+    "infrastructure/error": 1,
+    "skipped/not-completed": 2,
+    "passed": 3,
+}
+OUTCOME_CSS_CLASS = {
+    "passed": "passed",
+    "sample failure": "failed",
+    "infrastructure/error": "errored",
+    "skipped/not-completed": "skipped",
+}
+
+# Small inline SVG download glyph for the Artifact column -- avoids pulling
+# in an external icon font or network dependency on a page that must render
+# standalone from a GitHub Pages deployment.
+DOWNLOAD_ICON = (
+    '<svg class="icon-download" viewBox="0 0 16 16" width="14" height="14" '
+    'aria-hidden="true" focusable="false">'
+    '<path fill="currentColor" d="M8 1a1 1 0 0 1 1 1v6.586l2.293-2.293a1 1 0 0 1 '
+    '1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L7 8.586V2a1 1 0 0 1 1-1z"/>'
+    '<path fill="currentColor" d="M2 12a1 1 0 0 1 1 1v1h10v-1a1 1 0 1 1 2 0v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1z"/>'
+    "</svg>"
+)
+
+
+def esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def run_metadata(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return next((record.get("run") for record in records if record.get("run")), {})
+
+
+def run_link(run: dict[str, Any], run_url: str | None) -> str | None:
+    repository = run.get("repository")
+    if run_url:
+        return run_url
+    run_id = run.get("run_id")
+    if (
+        isinstance(repository, str)
+        and REPOSITORY_PATTERN.fullmatch(repository)
+        and isinstance(run_id, str)
+        and run_id.isdigit()
+    ):
+        return f"https://github.com/{repository}/actions/runs/{run_id}"
+    return None
+
+
+def commit_link(run: dict[str, Any]) -> str | None:
+    repository = run.get("repository")
+    sha = run.get("sha")
+    if (
+        isinstance(repository, str)
+        and REPOSITORY_PATTERN.fullmatch(repository)
+        and isinstance(sha, str)
+        and SHA_PATTERN.fullmatch(sha)
+    ):
+        return f"https://github.com/{repository}/commit/{sha}"
+    return None
+
+
+def load_link_map(path: Path | None, repository: str | None, url_suffix_pattern: str) -> dict[str, str]:
+    """Load an optional sample-id -> URL map produced by the workflow.
+
+    Used both for per-sample job links and per-sample artifact links. It's
+    best-effort: if the file is missing, malformed, or a URL doesn't match
+    the expected GitHub URL shape for this run's own repository, that entry
+    (or the whole map) is silently dropped and the caller falls back to a
+    less specific link.
+    """
+    if not path or not path.is_file() or not repository or not REPOSITORY_PATTERN.fullmatch(repository):
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    pattern = re.compile(rf"^https://github\.com/{re.escape(repository)}/{url_suffix_pattern}$")
+    return {
+        sample_id: url
+        for sample_id, url in raw.items()
+        if isinstance(sample_id, str) and isinstance(url, str) and pattern.fullmatch(url)
+    }
+
+
+def load_codeowners(path: Path | None) -> list[tuple[str, str]]:
+    """Parse a CODEOWNERS file into an ordered list of (pattern, owners).
+
+    Patterns are kept exactly as written (leading "/" stripped, trailing "/"
+    kept so directory patterns are distinguishable from file patterns).
+    Best-effort: a missing or unreadable file just yields no entries, so the
+    Codeowner column falls back to "—" everywhere rather than failing the
+    whole render.
+    """
+    if not path or not path.is_file():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    entries: list[tuple[str, str]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        if len(parts) < 2:
+            continue
+        pattern, owners = parts[0], " ".join(parts[1:])
+        entries.append((pattern.lstrip("/"), owners))
+    return entries
+
+
+def codeowners_for(sample_path: str, codeowners: list[tuple[str, str]]) -> list[str]:
+    """Return the distinct owner handles/teams for a sample.
+
+    Combines two kinds of CODEOWNERS entries:
+      - The directory-level entry that governs the sample as a whole (the
+        pattern is the sample path itself or an ancestor directory of it),
+        using CODEOWNERS' own "last matching entry wins" rule for that tier.
+      - Any more specific entries nested *inside* the sample directory (e.g.
+        a single file referenced from docs, such as
+        "/samples/.../Program.cs @microsoft-foundry/AI-Platform-Docs"). These
+        don't replace the directory owner -- they're additional reviewers
+        with a real stake in that sample -- so their owners are unioned in
+        rather than discarded.
+    Returned in encounter order (directory owner's tokens first), deduplicated.
+    """
+    primary_owners: str | None = None
+    nested_owner_tokens: list[str] = []
+    for pattern, pattern_owners in codeowners:
+        pattern_dir = pattern.rstrip("/")
+        if sample_path == pattern_dir or sample_path.startswith(pattern_dir + "/"):
+            primary_owners = pattern_owners
+        elif pattern_dir.startswith(sample_path + "/"):
+            nested_owner_tokens.extend(pattern_owners.split())
+    tokens: list[str] = list(primary_owners.split()) if primary_owners else []
+    for token in nested_owner_tokens:
+        if token not in tokens:
+            tokens.append(token)
+    return tokens
+
+
+def codeowner_display_name(owner: str) -> str:
+    """Strip a leading '@org/' prefix for the Codeowner column's display text.
+
+    Filter buttons and the underlying data-codeowner match tokens keep the
+    full "@org/team" form; only the visible cell text is shortened.
+    """
+    if owner.startswith("@") and "/" in owner:
+        return "@" + owner.split("/", 1)[1]
+    return owner
+
+
+def render_row(
+    record: dict[str, Any],
+    status_href: str | None,
+    artifact_href: str | None,
+    codeowners: list[str] | None,
+) -> str:
+    sample = record["sample"]
+    url = sample_url(record)
+    path_cell = f'<a href="{esc(url)}"><code>{esc(sample["path"])}</code></a>' if url else f'<code>{esc(sample["path"])}</code>'
+    completed_at = record.get("completed_at")
+    completed_sort = completed_at.isoformat() if isinstance(completed_at, datetime) else ""
+    completed_cell = esc(completed_at.strftime("%Y-%m-%d %H:%M UTC")) if isinstance(completed_at, datetime) else "—"
+    duration = record.get("duration_seconds")
+    duration_sort = duration if isinstance(duration, (int, float)) else -1
+    duration_cell = f"{esc(duration)}s" if isinstance(duration, (int, float)) else "—"
+    outcome = record["outcome"]
+    badge_text = esc(OUTCOMES.get(outcome, outcome))
+    badge = f'<span class="badge {OUTCOME_CSS_CLASS.get(outcome, "")}">{badge_text}</span>'
+    status_cell = f'<a href="{esc(status_href)}">{badge}</a>' if status_href else badge
+    artifact_sort = "1" if artifact_href else "0"
+    artifact_cell = (
+        f'<a href="{esc(artifact_href)}" class="artifact-link">{DOWNLOAD_ICON}Diagnostics</a>' if artifact_href else "—"
+    )
+    stage = record.get("completed_stage", "—")
+    owners = codeowners or []
+    codeowner_display = ", ".join(codeowner_display_name(owner) for owner in owners)
+    codeowner_cell = esc(codeowner_display) if owners else "—"
+    codeowner_tokens = " ".join(esc(owner.lower()) for owner in owners)
+    return (
+        f'<tr data-outcome="{esc(outcome)}" data-language="{esc(sample["language"].lower())}" '
+        f'data-codeowner="{codeowner_tokens}">'
+        f'<td data-sort-value="{esc(sample["path"].lower())}">{path_cell}</td>'
+        f'<td data-sort-value="{esc(sample["language"].lower())}">{esc(sample["language"])}</td>'
+        f'<td data-sort-value="{OUTCOME_RANK.get(outcome, 99)}">{status_cell}</td>'
+        f'<td data-sort-value="{esc(stage.lower())}">{esc(stage)}</td>'
+        f'<td data-sort-value="{duration_sort}">{duration_cell}</td>'
+        f'<td data-sort-value="{esc(completed_sort)}">{completed_cell}</td>'
+        f'<td data-sort-value="{artifact_sort}">{artifact_cell}</td>'
+        f'<td data-sort-value="{esc(codeowner_display.lower())}">{codeowner_cell}</td>'
+        "</tr>"
+    )
+
+
+SORT_SCRIPT = """
+(function () {
+  var table = document.getElementById("results");
+  if (!table) return;
+  var headers = table.querySelectorAll("th[data-sort-index]");
+  var currentIndex = null;
+  var currentDir = 1;
+  headers.forEach(function (th) {
+    th.addEventListener("click", function () {
+      var index = parseInt(th.getAttribute("data-sort-index"), 10);
+      var type = th.getAttribute("data-sort-type") || "text";
+      currentDir = index === currentIndex ? -currentDir : 1;
+      currentIndex = index;
+      var tbody = table.tBodies[0];
+      var rows = Array.prototype.slice.call(tbody.rows);
+      rows.sort(function (a, b) {
+        var av = a.cells[index].getAttribute("data-sort-value") || "";
+        var bv = b.cells[index].getAttribute("data-sort-value") || "";
+        if (type === "number") {
+          av = parseFloat(av); bv = parseFloat(bv);
+          return (av - bv) * currentDir;
+        }
+        if (av < bv) return -1 * currentDir;
+        if (av > bv) return 1 * currentDir;
+        return 0;
+      });
+      rows.forEach(function (row) { tbody.appendChild(row); });
+      headers.forEach(function (other) { other.removeAttribute("data-sort-dir"); });
+      th.setAttribute("data-sort-dir", currentDir === 1 ? "asc" : "desc");
+    });
+  });
+})();
+"""
+
+FILTER_SCRIPT = """
+(function () {
+  var table = document.getElementById("results");
+  if (!table) return;
+  var rows = table.tBodies[0].rows;
+  var groups = [
+    { bar: document.getElementById("outcome-filters"), attr: "data-filter-outcome", data: "outcome", active: "all" },
+    { bar: document.getElementById("language-filters"), attr: "data-filter-language", data: "language", active: "all" },
+    { bar: document.getElementById("codeowner-filters"), attr: "data-filter-codeowner", data: "codeowner", active: "all", multi: true },
+  ].filter(function (group) { return group.bar; });
+  if (!groups.length) return;
+
+  function matches(row, group) {
+    if (group.active === "all") return true;
+    var value = row.getAttribute("data-" + group.data) || "";
+    if (group.multi) {
+      // A row can have several codeowners (e.g. a directory owner plus a
+      // docs-team file-level owner) -- match if the active filter is one of them.
+      // An empty active value (the "Unowned" bucket) matches rows with none.
+      return group.active === "" ? value === "" : value.split(" ").indexOf(group.active) !== -1;
+    }
+    return value === group.active;
+  }
+
+  function applyFilters() {
+    Array.prototype.forEach.call(rows, function (row) {
+      var visible = groups.every(function (group) { return matches(row, group); });
+      row.style.display = visible ? "" : "none";
+    });
+  }
+
+  groups.forEach(function (group) {
+    var buttons = group.bar.querySelectorAll("button[" + group.attr + "]");
+    buttons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        group.active = button.getAttribute(group.attr);
+        buttons.forEach(function (other) { other.classList.remove("active"); });
+        button.classList.add("active");
+        applyFilters();
+      });
+    });
+  });
+})();
+"""
+
+
+def render(
+    records: list[dict[str, Any]],
+    complete: bool,
+    run_url: str | None,
+    generated_at: datetime,
+    job_links: dict[str, str] | None = None,
+    artifact_links: dict[str, str] | None = None,
+    codeowners: list[tuple[str, str]] | None = None,
+) -> str:
+    counts = {outcome: sum(record["outcome"] == outcome for record in records) for outcome in OUTCOMES}
+    run = run_metadata(records)
+    rlink = run_link(run, run_url)
+    clink = commit_link(run)
+    sha = run.get("sha")
+
+    status_lines = []
+    if not complete:
+        status_lines.append(
+            '<div class="banner banner-incomplete">'
+            "⚠️ The most recent scheduled run reported an <strong>incomplete</strong> result set. "
+            "This snapshot is not authoritative fleet status — open the workflow run linked below "
+            "for the details that could not be normalized here."
+            "</div>"
+        )
+    meta_bits = [f"Generated {esc(generated_at.strftime('%Y-%m-%d %H:%M UTC'))}"]
+    if run.get("run_id") and run.get("run_attempt"):
+        meta_bits.append(f"Run {esc(run['run_id'])} · attempt {esc(run['run_attempt'])}")
+    if sha and clink:
+        meta_bits.append(f'Validated commit <a href="{esc(clink)}"><code>{esc(str(sha)[:12])}</code></a>')
+    elif sha:
+        meta_bits.append(f"Validated commit <code>{esc(str(sha)[:12])}</code>")
+    if rlink:
+        meta_bits.append(f'<a href="{esc(rlink)}">Workflow run</a>')
+    status_lines.append(f'<p class="meta">{" · ".join(meta_bits)}</p>')
+
+    filter_buttons = [f'<button type="button" data-filter-outcome="all" class="active">All ({len(records)})</button>']
+    for outcome in ("passed", "sample failure", "infrastructure/error", "skipped/not-completed"):
+        filter_buttons.append(
+            f'<button type="button" data-filter-outcome="{esc(outcome)}" class="filter-btn {OUTCOME_CSS_CLASS.get(outcome, "")}">'
+            f"{esc(OUTCOMES[outcome])} ({counts[outcome]})</button>"
+        )
+    status_lines.append(f'<div id="outcome-filters" class="filters">{"".join(filter_buttons)}</div>')
+
+    language_counts: dict[str, int] = {}
+    for record in records:
+        language = record["sample"]["language"]
+        language_counts[language] = language_counts.get(language, 0) + 1
+    language_buttons = [f'<button type="button" data-filter-language="all" class="active">All ({len(records)})</button>']
+    for language in sorted(language_counts, key=str.lower):
+        language_buttons.append(
+            f'<button type="button" data-filter-language="{esc(language.lower())}" class="filter-btn">'
+            f"{esc(language)} ({language_counts[language]})</button>"
+        )
+    status_lines.append(f'<div id="language-filters" class="filters">{"".join(language_buttons)}</div>')
+
+    codeowners = codeowners or []
+    sample_codeowners = {
+        record["sample"]["id"]: codeowners_for(record["sample"]["path"], codeowners) for record in records
+    }
+    codeowner_counts: dict[str, int] = {}
+    unowned_count = 0
+    for owners in sample_codeowners.values():
+        if not owners:
+            unowned_count += 1
+            continue
+        for owner in owners:
+            codeowner_counts[owner] = codeowner_counts.get(owner, 0) + 1
+    codeowner_buttons = [f'<button type="button" data-filter-codeowner="all" class="active">All ({len(records)})</button>']
+    for owner in sorted(codeowner_counts, key=str.lower):
+        codeowner_buttons.append(
+            f'<button type="button" data-filter-codeowner="{esc(owner.lower())}" class="filter-btn">'
+            f"{esc(codeowner_display_name(owner))} ({codeowner_counts[owner]})</button>"
+        )
+    if unowned_count:
+        codeowner_buttons.append(
+            f'<button type="button" data-filter-codeowner="" class="filter-btn">Unowned ({unowned_count})</button>'
+        )
+    status_lines.append(f'<div id="codeowner-filters" class="filters">{"".join(codeowner_buttons)}</div>')
+
+    # Prefer linking each row straight to the specific matrix job that
+    # produced it -- that job page shows the failing step directly. Only
+    # fall back to the overall run-overview link when no per-sample job
+    # link was collected (e.g. running this script standalone/locally).
+    job_links = job_links or {}
+    artifact_links = artifact_links or {}
+    ordered_records = sorted(
+        records,
+        key=lambda record: (OUTCOME_RANK.get(record["outcome"], 99), record["sample"]["language"], record["sample"]["path"]),
+    )
+    rows = "\n".join(
+        render_row(
+            record,
+            job_links.get(record["sample"]["id"], rlink),
+            artifact_links.get(record["sample"]["id"]),
+            sample_codeowners.get(record["sample"]["id"]),
+        )
+        for record in ordered_records
+    )
+    columns = [
+        ("Sample", "text"),
+        ("Language", "text"),
+        ("Status", "number"),
+        ("Stage", "text"),
+        ("Duration", "number"),
+        ("Last checked", "text"),
+        ("Artifact", "number"),
+        ("Codeowner", "text"),
+    ]
+    header_cells = "".join(
+        f'<th data-sort-index="{index}" data-sort-type="{sort_type}">{esc(label)}<span class="sort-indicator"></span></th>'
+        for index, (label, sort_type) in enumerate(columns)
+    )
+    table = (
+        '<table id="results">'
+        f"<thead><tr>{header_cells}</tr></thead>"
+        f"<tbody>{rows}</tbody>"
+        "</table>"
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>foundry-samples validation dashboard</title>
+<style>
+  :root {{ color-scheme: light; }}
+  body {{
+    background: #ffffff; color: #1b1f23; margin: 0; padding: 2rem;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }}
+  h1 {{ margin-bottom: 0.25rem; }}
+  .meta {{ color: #57606a; margin: 0.25rem 0; }}
+  .filters {{ display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1rem 0; }}
+  .filters button {{
+    border: 1px solid #d0d7de; background: #f6f8fa; color: #1b1f23; border-radius: 999px;
+    padding: 0.3rem 0.85rem; font-size: 0.85rem; cursor: pointer; font-family: inherit;
+  }}
+  .filters button:hover {{ background: #eaeef2; }}
+  .filters button.active {{ background: #0969da; border-color: #0969da; color: #ffffff; }}
+  .filters button.passed.active {{ background: #1a7f37; border-color: #1a7f37; }}
+  .filters button.failed.active {{ background: #cf222e; border-color: #cf222e; }}
+  .filters button.errored.active {{ background: #9a6700; border-color: #9a6700; }}
+  .filters button.skipped.active {{ background: #57606a; border-color: #57606a; }}
+  .banner {{ padding: 0.75rem 1rem; border-radius: 6px; margin: 1rem 0; }}
+  .banner-incomplete {{ background: #fff8c5; border: 1px solid #d4a72c; color: #6b5900; }}
+  table {{ border-collapse: collapse; width: 100%; background: #ffffff; margin-top: 1.5rem; }}
+  th, td {{ text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #d0d7de; font-size: 0.9rem; }}
+  th {{ background: #f6f8fa; color: #1b1f23; cursor: pointer; user-select: none; white-space: nowrap; }}
+  th:hover {{ background: #eaeef2; }}
+  th .sort-indicator::after {{ content: ""; margin-left: 0.35rem; color: #57606a; }}
+  th[data-sort-dir="asc"] .sort-indicator::after {{ content: "▲"; }}
+  th[data-sort-dir="desc"] .sort-indicator::after {{ content: "▼"; }}
+  code {{ background: #f6f8fa; padding: 0.1rem 0.3rem; border-radius: 4px; }}
+  a {{ color: #0969da; text-decoration: none; }}
+  a:hover {{ text-decoration: underline; }}
+  .artifact-link {{ display: inline-flex; align-items: center; gap: 0.3rem; white-space: nowrap; }}
+  .icon-download {{ flex: none; }}
+  .badge {{ display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; font-size: 0.85rem; white-space: nowrap; }}
+  .badge.passed {{ background: #dafbe1; color: #116329; }}
+  .badge.failed {{ background: #ffebe9; color: #82071e; }}
+  .badge.errored {{ background: #fff8c5; color: #6b5900; }}
+  .badge.skipped {{ background: #eaeef2; color: #57606a; }}
+  footer {{ margin-top: 2rem; color: #57606a; font-size: 0.85rem; }}
+</style>
+</head>
+<body>
+<h1>foundry-samples validation dashboard</h1>
+{"".join(status_lines)}
+{table}
+<footer>
+  Diagnostics are intentionally omitted from this page. Click a status badge,
+  or open the workflow run above, for full logs, subject to GitHub Actions
+  retention and authentication. Click any column header to sort.
+</footer>
+<script>{SORT_SCRIPT}
+{FILTER_SCRIPT}</script>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", type=Path, required=True)
+    parser.add_argument("--expected-samples", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--run-url")
+    parser.add_argument(
+        "--job-links",
+        type=Path,
+        help="optional JSON file mapping sample id -> matrix job URL, as produced by collect-job-links.py",
+    )
+    parser.add_argument(
+        "--artifact-links",
+        type=Path,
+        help="optional JSON file mapping sample id -> artifact page URL, as produced by collect-artifact-links.py",
+    )
+    parser.add_argument(
+        "--codeowners",
+        type=Path,
+        help="optional path to a CODEOWNERS file used to populate the Codeowner column/filter",
+    )
+    args = parser.parse_args()
+    try:
+        records, complete = collect(args.results_dir, load_expected(args.expected_samples))
+        run = run_metadata(records)
+        repository = run.get("repository")
+        job_links = load_link_map(args.job_links, repository, r"actions/runs/\d+/job/\d+")
+        artifact_links = load_link_map(args.artifact_links, repository, r"actions/runs/\d+/artifacts/\d+")
+        codeowners = load_codeowners(args.codeowners)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            render(
+                records,
+                complete,
+                args.run_url,
+                datetime.now(timezone.utc),
+                job_links,
+                artifact_links,
+                codeowners,
+            ),
+            encoding="utf-8",
+            newline="\n",
+        )
+    except (ContractError, OSError) as exc:
+        print(f"render-validation-dashboard: {exc}", file=sys.stderr)
+        return 1
+    # Unlike render-validation-report.py, an incomplete result set does not
+    # fail this script: the dashboard must still publish (with its banner)
+    # so a broken handoff is visible on the durable page rather than leaving
+    # a stale prior deployment looking like current status.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -499,9 +499,9 @@ def render(
 {"".join(status_lines)}
 {table}
 <footer>
-  Diagnostics are intentionally omitted from this page. Click a status badge,
-  or open the workflow run above, for full logs, subject to GitHub Actions
-  retention and authentication. Click any column header to sort.
+  Full diagnostic logs aren't inlined on this page. Click a status badge, or
+  the Diagnostics link when present, for per-sample logs, subject to GitHub
+  Actions retention and authentication. Click any column header to sort.
 </footer>
 <script>{SORT_SCRIPT}
 {FILTER_SCRIPT}</script>

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -62,6 +62,14 @@ OUTCOME_CSS_CLASS = {
     "infrastructure/error": "errored",
     "skipped/not-completed": "skipped",
 }
+STAGE_LABELS = {
+    "inventory eligibility": "Not validated",
+    "build readiness validation": "Build check",
+    "build readiness invocation": "Build check setup error",
+    "live-service validation": "Live run",
+    "live-service validation invocation": "Live run setup error",
+    "reporting": "Reporting issue",
+}
 
 # Small inline SVG download glyph for the Artifact column -- avoids pulling
 # in an external icon font or network dependency on a page that must render
@@ -78,6 +86,12 @@ DOWNLOAD_ICON = (
 
 def esc(value: Any) -> str:
     return html.escape(str(value), quote=True)
+
+
+def stage_label(stage: Any) -> str:
+    if not isinstance(stage, str) or not stage:
+        return "Unknown"
+    return STAGE_LABELS.get(stage, stage)
 
 
 def run_metadata(records: list[dict[str, Any]]) -> dict[str, Any]:
@@ -133,7 +147,7 @@ def copilot_issue_link(
         f"- Sample: `{sample['path']}`",
         f"- Language: `{sample['language']}`",
         f"- Outcome: `{record['outcome']}`",
-        f"- Stage: `{record.get('completed_stage', 'unknown')}`",
+        f"- Validation: `{stage_label(record.get('completed_stage'))}`",
     ]
     if isinstance(run_id, str) and run_id.isdigit():
         details.append(f"- Run ID: `{run_id}`")
@@ -294,7 +308,9 @@ def render_row(
         else "—"
     )
     copilot_sort = "1" if copilot_href else "0"
-    stage = record.get("completed_stage", "—")
+    stage = record.get("completed_stage", "")
+    stage_display = stage_label(stage)
+    stage_title = f' title="{esc(stage)}"' if isinstance(stage, str) and stage != stage_display else ""
     owners = codeowners or []
     codeowner_display = ", ".join(codeowner_display_name(owner) for owner in owners)
     codeowner_cell = esc(codeowner_display) if owners else "—"
@@ -305,7 +321,7 @@ def render_row(
         f'<td data-sort-value="{esc(sample["path"].lower())}">{path_cell}</td>'
         f'<td data-sort-value="{esc(sample["language"].lower())}">{esc(sample["language"])}</td>'
         f'<td data-sort-value="{OUTCOME_RANK.get(outcome, 99)}">{status_cell}</td>'
-        f'<td data-sort-value="{esc(stage.lower())}">{esc(stage)}</td>'
+        f'<td data-sort-value="{esc(str(stage).lower())}"{stage_title}>{esc(stage_display)}</td>'
         f'<td data-sort-value="{duration_sort}">{duration_cell}</td>'
         f'<td data-sort-value="{esc(completed_sort)}">{completed_cell}</td>'
         f'<td data-sort-value="{artifact_sort}">{artifact_cell}</td>'
@@ -504,7 +520,7 @@ def render(
         ("Sample", "text"),
         ("Language", "text"),
         ("Status", "number"),
-        ("Stage", "text"),
+        ("Validation", "text"),
         ("Duration", "number"),
         ("Last checked", "text"),
         ("Artifact", "number"),

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -317,7 +317,7 @@ def render_row(
     codeowner_tokens = " ".join(esc(owner.lower()) for owner in owners)
     return (
         f'<tr data-outcome="{esc(outcome)}" data-language="{esc(sample["language"].lower())}" '
-        f'data-codeowner="{codeowner_tokens}">'
+        f'data-validation="{esc(str(stage).lower())}" data-codeowner="{codeowner_tokens}">'
         f'<td data-sort-value="{esc(sample["path"].lower())}">{path_cell}</td>'
         f'<td data-sort-value="{esc(sample["language"].lower())}">{esc(sample["language"])}</td>'
         f'<td data-sort-value="{OUTCOME_RANK.get(outcome, 99)}">{status_cell}</td>'
@@ -378,11 +378,14 @@ FILTER_SCRIPT = """
   if (!table) return;
   var rows = table.tBodies[0].rows;
   var groups = [
-    { bar: document.getElementById("outcome-filters"), attr: "data-filter-outcome", data: "outcome", active: "all" },
-    { bar: document.getElementById("language-filters"), attr: "data-filter-language", data: "language", active: "all" },
-    { bar: document.getElementById("codeowner-filters"), attr: "data-filter-codeowner", data: "codeowner", active: "all", multi: true },
+  { bar: document.getElementById("outcome-filters"), attr: "data-filter-outcome", data: "outcome", label: "Status", active: "all" },
+  { bar: document.getElementById("language-filters"), attr: "data-filter-language", data: "language", label: "Language", active: "all" },
+  { bar: document.getElementById("validation-filters"), attr: "data-filter-validation", data: "validation", label: "Validation", active: "all" },
+  { bar: document.getElementById("codeowner-filters"), attr: "data-filter-codeowner", data: "codeowner", label: "Codeowner", active: "all", multi: true },
   ].filter(function (group) { return group.bar; });
   if (!groups.length) return;
+  var summary = document.getElementById("filter-summary");
+  var total = rows.length;
 
   function matches(row, group) {
     if (group.active === "all") return true;
@@ -397,10 +400,23 @@ FILTER_SCRIPT = """
   }
 
   function applyFilters() {
+    var visibleCount = 0;
     Array.prototype.forEach.call(rows, function (row) {
       var visible = groups.every(function (group) { return matches(row, group); });
       row.style.display = visible ? "" : "none";
+      if (visible) visibleCount += 1;
     });
+    if (summary) {
+      var active = groups
+        .filter(function (group) { return group.active !== "all"; })
+        .map(function (group) {
+          var button = group.bar.querySelector("button.active");
+          var label = button ? button.textContent.replace(/\\s*\\([^)]*\\)\\s*$/, "") : group.active;
+          return group.label + ": " + label;
+        });
+      summary.textContent = "Showing " + visibleCount + " of " + total + " samples" +
+        (active.length ? " · " + active.join(" · ") : " · All filters");
+    }
   }
 
   groups.forEach(function (group) {
@@ -414,6 +430,7 @@ FILTER_SCRIPT = """
       });
     });
   });
+  applyFilters();
 })();
 """
 
@@ -453,13 +470,16 @@ def render(
         meta_bits.append(f'<a href="{esc(rlink)}">Workflow run</a>')
     status_lines.append(f'<p class="meta">{" · ".join(meta_bits)}</p>')
 
+    filter_sections = []
     filter_buttons = [f'<button type="button" data-filter-outcome="all" class="active">All ({len(records)})</button>']
     for outcome in ("passed", "sample failure", "infrastructure/error", "skipped/not-completed"):
         filter_buttons.append(
             f'<button type="button" data-filter-outcome="{esc(outcome)}" class="filter-btn {OUTCOME_CSS_CLASS.get(outcome, "")}">'
             f"{esc(OUTCOMES[outcome])} ({counts[outcome]})</button>"
         )
-    status_lines.append(f'<div id="outcome-filters" class="filters">{"".join(filter_buttons)}</div>')
+    filter_sections.append(
+        f'<div class="filter-group"><strong>Status</strong><div id="outcome-filters" class="filters">{"".join(filter_buttons)}</div></div>'
+    )
 
     language_counts: dict[str, int] = {}
     for record in records:
@@ -471,7 +491,26 @@ def render(
             f'<button type="button" data-filter-language="{esc(language.lower())}" class="filter-btn">'
             f"{esc(language)} ({language_counts[language]})</button>"
         )
-    status_lines.append(f'<div id="language-filters" class="filters">{"".join(language_buttons)}</div>')
+    filter_sections.append(
+        f'<div class="filter-group"><strong>Language</strong><div id="language-filters" class="filters">{"".join(language_buttons)}</div></div>'
+    )
+
+    validation_counts: dict[str, int] = {}
+    validation_labels: dict[str, str] = {}
+    for record in records:
+        stage = record.get("completed_stage", "")
+        key = str(stage).lower()
+        validation_counts[key] = validation_counts.get(key, 0) + 1
+        validation_labels[key] = stage_label(stage)
+    validation_buttons = [f'<button type="button" data-filter-validation="all" class="active">All ({len(records)})</button>']
+    for key in sorted(validation_counts, key=lambda value: validation_labels[value].lower()):
+        validation_buttons.append(
+            f'<button type="button" data-filter-validation="{esc(key)}" class="filter-btn">'
+            f"{esc(validation_labels[key])} ({validation_counts[key]})</button>"
+        )
+    filter_sections.append(
+        f'<div class="filter-group"><strong>Validation</strong><div id="validation-filters" class="filters">{"".join(validation_buttons)}</div></div>'
+    )
 
     codeowners = codeowners or []
     sample_codeowners = {
@@ -495,7 +534,15 @@ def render(
         codeowner_buttons.append(
             f'<button type="button" data-filter-codeowner="" class="filter-btn">Unowned ({unowned_count})</button>'
         )
-    status_lines.append(f'<div id="codeowner-filters" class="filters">{"".join(codeowner_buttons)}</div>')
+    filter_sections.append(
+        f'<div class="filter-group"><strong>Codeowner</strong><div id="codeowner-filters" class="filters">{"".join(codeowner_buttons)}</div></div>'
+    )
+    status_lines.append(
+        '<details class="filter-panel">'
+        '<summary><strong>Filters</strong><span id="filter-summary">Showing all samples</span></summary>'
+        f'{"".join(filter_sections)}'
+        "</details>"
+    )
 
     # Prefer linking each row straight to the specific matrix job that
     # produced it -- that job page shows the failing step directly. Only
@@ -553,7 +600,19 @@ def render(
   }}
   h1 {{ margin-bottom: 0.25rem; }}
   .meta {{ color: #57606a; margin: 0.25rem 0; }}
-  .filters {{ display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 1rem 0; }}
+  .filter-panel {{
+    border: 1px solid #d0d7de; border-radius: 8px; margin: 1rem 0; background: #ffffff;
+  }}
+  .filter-panel summary {{
+    display: flex; align-items: center; gap: 0.75rem; cursor: pointer; padding: 0.75rem 1rem;
+  }}
+  .filter-panel summary::-webkit-details-marker {{ display: none; }}
+  .filter-panel summary::before {{ content: "▸"; color: #57606a; }}
+  .filter-panel[open] summary::before {{ content: "▾"; }}
+  #filter-summary {{ color: #57606a; font-size: 0.9rem; }}
+  .filter-group {{ border-top: 1px solid #d0d7de; padding: 0.75rem 1rem; }}
+  .filter-group strong {{ display: block; margin-bottom: 0.5rem; }}
+  .filters {{ display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0; }}
   .filters button {{
     border: 1px solid #d0d7de; background: #f6f8fa; color: #1b1f23; border-radius: 999px;
     padding: 0.3rem 0.85rem; font-size: 0.85rem; cursor: pointer; font-family: inherit;

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -36,6 +36,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
 from validation_pilot_common import (
     OUTCOMES,
@@ -109,6 +110,64 @@ def commit_link(run: dict[str, Any]) -> str | None:
     ):
         return f"https://github.com/{repository}/commit/{sha}"
     return None
+
+
+def copilot_issue_link(
+    record: dict[str, Any],
+    status_href: str | None,
+    artifact_href: str | None,
+) -> str | None:
+    """Build a review-before-submit issue that assigns the failure to Copilot."""
+    if record["outcome"] not in {"sample failure", "infrastructure/error"}:
+        return None
+
+    sample = record["sample"]
+    run = record.get("run", {})
+    repository = run.get("repository")
+    if not isinstance(repository, str) or not REPOSITORY_PATTERN.fullmatch(repository):
+        return None
+
+    run_id = run.get("run_id")
+    sha = run.get("sha")
+    details = [
+        f"- Sample: `{sample['path']}`",
+        f"- Language: `{sample['language']}`",
+        f"- Outcome: `{record['outcome']}`",
+        f"- Stage: `{record.get('completed_stage', 'unknown')}`",
+    ]
+    if isinstance(run_id, str) and run_id.isdigit():
+        details.append(f"- Run ID: `{run_id}`")
+    if isinstance(sha, str) and SHA_PATTERN.fullmatch(sha):
+        details.append(f"- Validated commit: `{sha}`")
+    if status_href:
+        details.append(f"- Workflow job: {status_href}")
+    if artifact_href:
+        details.append(f"- Diagnostic artifact: {artifact_href}")
+
+    body = "\n".join(
+        [
+            "## Validation failure",
+            "",
+            *details,
+            "",
+            "## Task",
+            "",
+            "Investigate this validation failure and determine the root cause. "
+            "Download and inspect the diagnostic artifact when available, reproduce "
+            "the failure, and make the smallest appropriate fix without weakening "
+            "validation. Run the relevant tests and open a pull request with the fix.",
+            "",
+            "> Created from the foundry-samples validation dashboard.",
+        ]
+    )
+    query = urlencode(
+        {
+            "title": f"Fix validation failure: {sample['path']}",
+            "body": body,
+            "assignees": "copilot-swe-agent[bot]",
+        }
+    )
+    return f"https://github.com/{repository}/issues/new?{query}"
 
 
 def load_link_map(path: Path | None, repository: str | None, url_suffix_pattern: str) -> dict[str, str]:
@@ -228,6 +287,13 @@ def render_row(
     artifact_cell = (
         f'<a href="{esc(artifact_href)}" class="artifact-link">{DOWNLOAD_ICON}Diagnostics</a>' if artifact_href else "—"
     )
+    copilot_href = copilot_issue_link(record, status_href, artifact_href)
+    copilot_cell = (
+        f'<a href="{esc(copilot_href)}" class="copilot-link">Fix with Copilot ↗</a>'
+        if copilot_href
+        else "—"
+    )
+    copilot_sort = "1" if copilot_href else "0"
     stage = record.get("completed_stage", "—")
     owners = codeowners or []
     codeowner_display = ", ".join(codeowner_display_name(owner) for owner in owners)
@@ -244,6 +310,7 @@ def render_row(
         f'<td data-sort-value="{esc(completed_sort)}">{completed_cell}</td>'
         f'<td data-sort-value="{artifact_sort}">{artifact_cell}</td>'
         f'<td data-sort-value="{esc(codeowner_display.lower())}">{codeowner_cell}</td>'
+        f'<td data-sort-value="{copilot_sort}">{copilot_cell}</td>'
         "</tr>"
     )
 
@@ -442,6 +509,7 @@ def render(
         ("Last checked", "text"),
         ("Artifact", "number"),
         ("Codeowner", "text"),
+        ("Action", "number"),
     ]
     header_cells = "".join(
         f'<th data-sort-index="{index}" data-sort-type="{sort_type}" aria-sort="none">'
@@ -498,7 +566,7 @@ def render(
   code {{ background: #f6f8fa; padding: 0.1rem 0.3rem; border-radius: 4px; }}
   a {{ color: #0969da; text-decoration: none; }}
   a:hover {{ text-decoration: underline; }}
-  .artifact-link {{ display: inline-flex; align-items: center; gap: 0.3rem; white-space: nowrap; }}
+  .artifact-link, .copilot-link {{ display: inline-flex; align-items: center; gap: 0.3rem; white-space: nowrap; }}
   .icon-download {{ flex: none; }}
   .badge {{ display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; font-size: 0.85rem; white-space: nowrap; }}
   .badge.passed {{ background: #dafbe1; color: #116329; }}
@@ -515,7 +583,9 @@ def render(
 <footer>
   Full diagnostic logs aren't inlined on this page. Click a status badge, or
   the Diagnostics link when present, for per-sample logs, subject to GitHub
-  Actions retention and authentication. Click any column header to sort.
+  Actions retention and authentication. For failed or errored samples, Fix
+  with Copilot opens a prefilled issue for review; submitting it assigns the
+  investigation to Copilot. Click any column header to sort.
 </footer>
 <script>{SORT_SCRIPT}
 {FILTER_SCRIPT}</script>

--- a/.github/scripts/render-validation-dashboard.py
+++ b/.github/scripts/render-validation-dashboard.py
@@ -607,7 +607,7 @@ def render(
     display: flex; align-items: center; gap: 0.75rem; cursor: pointer; padding: 0.75rem 1rem;
   }}
   .filter-panel summary::-webkit-details-marker {{ display: none; }}
-  .filter-panel summary::before {{ content: "▸"; color: #57606a; }}
+  .filter-panel summary::before {{ content: "▸"; color: #57606a; font-size: 1.15rem; line-height: 1; }}
   .filter-panel[open] summary::before {{ content: "▾"; }}
   #filter-summary {{ color: #57606a; font-size: 0.9rem; }}
   .filter-group {{ border-top: 1px solid #d0d7de; padding: 0.75rem 1rem; }}

--- a/.github/scripts/render-validation-report.py
+++ b/.github/scripts/render-validation-report.py
@@ -4,25 +4,21 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
 
-OUTCOMES = {
-    "passed": "✅ Passed",
-    "sample failure": "❌ Sample failure",
-    "infrastructure/error": "⚠️ Infrastructure/error",
-    "skipped/not-completed": "⏭️ Skipped/not-completed",
-}
-REQUIRED = {
-    "schema_version", "sample", "outcome", "completed_stage", "duration_seconds",
-    "diagnostic_reference", "artifact_reference", "completed_at", "run",
-}
-RUN_FIELDS = {"repository", "workflow", "run_id", "run_attempt", "sha", "ref", "started_at"}
+from validation_pilot_common import (
+    OUTCOMES,
+    REPOSITORY_PATTERN,
+    SHA_PATTERN,
+    ContractError,
+    collect as _common_collect,
+    load_expected,
+    sample_url,
+)
+
 SECTION_ORDER = ("sample failure", "infrastructure/error", "skipped/not-completed", "passed")
 SECTION_LABELS = {
     "sample failure": "Sample failures",
@@ -30,158 +26,17 @@ SECTION_LABELS = {
     "skipped/not-completed": "Skipped/not-completed",
 }
 DIAGNOSTIC_LIMIT = 240
-SUPPORTED_SCHEMA_VERSIONS = {1, 2}
-LEGACY_COMPLETED_STAGES = {
-    "L3 validation": "build readiness validation",
-    "L3 validation invocation": "build readiness invocation",
-    "L4 validation": "live-service validation",
-    "L4 validation invocation": "live-service validation invocation",
-}
 DIAGNOSTIC_PATTERNS = (
     re.compile(r"(?:\berror\b|^FAIL:|^ERROR:|^SKIP:|^runner error:)", re.IGNORECASE),
 )
 VERDICT_PATTERN = re.compile(r"^verdict=", re.IGNORECASE)
-REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
-
-
-class ContractError(ValueError):
-    pass
-
-
-def load_json(path: Path, label: str) -> Any:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise ContractError(f"{label} not found: {path}") from exc
-    except json.JSONDecodeError as exc:
-        raise ContractError(f"{label} is not valid JSON: {exc}") from exc
-
-
-def timestamp(value: Any, field: str) -> datetime:
-    if not isinstance(value, str) or not value.endswith("Z"):
-        raise ContractError(f"{field} must be an ISO-8601 UTC timestamp ending in Z")
-    try:
-        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
-    except ValueError as exc:
-        raise ContractError(f"{field} is not a valid timestamp") from exc
-    if parsed.utcoffset() != timezone.utc.utcoffset(parsed):
-        raise ContractError(f"{field} must be UTC")
-    return parsed
-
-
-def sample_identity(value: Any, field: str) -> dict[str, str]:
-    keys = {"id", "path", "language", "shape"}
-    if not isinstance(value, dict) or set(value) != keys:
-        raise ContractError(f"{field} must contain exactly id, path, language, and shape")
-    if any(not isinstance(value[key], str) or not value[key] for key in keys):
-        raise ContractError(f"{field} fields must be non-empty strings")
-    if not value["path"].startswith("samples/") or ".." in Path(value["path"]).parts:
-        raise ContractError(f"{field}.path must be a safe repository-relative samples/ path")
-    return {key: value[key] for key in keys}
-
-
-def load_expected(path: Path) -> list[dict[str, str]]:
-    payload = load_json(path, "sample manifest")
-    if (
-        not isinstance(payload, dict)
-        or payload.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
-        or not isinstance(payload.get("samples"), list)
-        or not payload["samples"]
-    ):
-        raise ContractError("sample manifest must contain a non-empty samples array")
-    samples = [sample_identity(value, "manifest sample") for value in payload["samples"]]
-    ids = [value["id"] for value in samples]
-    if ids != sorted(set(ids)):
-        raise ContractError("manifest samples must be sorted and unique by id")
-    return samples
-
-
-def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
-    value = load_json(path, f"result artifact {path}")
-    if (
-        not isinstance(value, dict)
-        or set(value) != REQUIRED
-        or value.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
-    ):
-        raise ContractError("result must be a supported schema object")
-    missing = REQUIRED - value.keys()
-    if missing:
-        raise ContractError(f"result is missing fields: {sorted(missing)}")
-    sample = sample_identity(value["sample"], "result sample")
-    if sample != expected:
-        raise ContractError(f"sample identity does not match manifest: {sample['id']}")
-    if value["outcome"] not in OUTCOMES:
-        raise ContractError(f"unsupported outcome: {value['outcome']!r}")
-    if not isinstance(value["completed_stage"], str) or not value["completed_stage"]:
-        raise ContractError("completed_stage must be non-empty")
-    if not isinstance(value["duration_seconds"], (int, float)) or isinstance(value["duration_seconds"], bool) or value["duration_seconds"] < 0:
-        raise ContractError("duration_seconds must be non-negative")
-    timestamp(value["completed_at"], "completed_at")
-    run = value["run"]
-    if not isinstance(run, dict) or set(run) != RUN_FIELDS:
-        raise ContractError(f"run is missing fields: {sorted(RUN_FIELDS - set(run or {}))}")
-    timestamp(run["started_at"], "run.started_at")
-    for field in ("diagnostic_reference", "artifact_reference"):
-        reference = value[field]
-        if (
-            not isinstance(reference, str)
-            or not reference
-            or Path(reference).is_absolute()
-            or ".." in Path(reference).parts
-            or len(Path(reference).parts) != 1
-        ):
-            raise ContractError(f"{field} must be a relative filename")
-    diagnostic = path.parent / value["diagnostic_reference"]
-    if not diagnostic.is_file():
-        raise ContractError(f"missing diagnostic: {diagnostic}")
-    completed_stage = LEGACY_COMPLETED_STAGES.get(
-        value["completed_stage"], value["completed_stage"]
-    )
-    return {
-        **value,
-        "completed_stage": completed_stage,
-        "completed_at": timestamp(value["completed_at"], "completed_at"),
-        "diagnostic_path": diagnostic,
-    }
 
 
 def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dict[str, Any]], bool]:
-    if not results_dir.is_dir():
-        raise ContractError(f"result artifact directory not found: {results_dir}")
-    expected_by_id = {value["id"]: value for value in expected}
-    records: dict[str, dict[str, Any]] = {}
-    incomplete = False
-    for path in sorted(results_dir.glob("*/sample-result.json")):
-        try:
-            raw = load_json(path, f"result artifact {path}")
-            sample_id = raw.get("sample", {}).get("id") if isinstance(raw, dict) else None
-            if sample_id not in expected_by_id:
-                raise ContractError(f"unexpected sample id: {sample_id}")
-            if sample_id in records:
-                raise ContractError(f"duplicate result artifact for {sample_id}")
-            record = load_record(path, expected_by_id[sample_id])
-            records[sample_id] = record
-        except ContractError as exc:
-            incomplete = True
-            records[f"invalid:{path}"] = {
-                "sample": {"id": path.name, "path": f"<invalid artifact: {path.name}>", "language": "reporting", "shape": "error"},
-                "outcome": "infrastructure/error", "completed_stage": "reporting",
-                "duration_seconds": 0, "completed_at": None,
-                "diagnostic_reference": "—", "artifact_reference": path.name, "run": {},
-                "error": str(exc),
-            }
-    for sample in expected:
-        if sample["id"] not in records:
-            incomplete = True
-            records[f"missing:{sample['id']}"] = {
-                "sample": sample, "outcome": "infrastructure/error",
-                "completed_stage": "reporting", "duration_seconds": 0,
-                "completed_at": None, "diagnostic_reference": "—",
-                "artifact_reference": "—", "run": {},
-                "error": f"expected result artifact is missing for {sample['id']}",
-            }
-    return sorted(records.values(), key=lambda value: value["sample"]["path"]), incomplete
+    """Wraps the shared collector, translating its `complete` flag back to
+    this module's historical `incomplete` return convention."""
+    records, complete = _common_collect(results_dir, expected)
+    return records, not complete
 
 
 def markdown_cell(value: Any) -> str:
@@ -193,21 +48,6 @@ def markdown_cell(value: Any) -> str:
         .replace("\r", " ")
         .replace("\n", " ")
     )
-
-
-def sample_url(record: dict[str, Any]) -> str | None:
-    run = record.get("run", {})
-    repository = run.get("repository")
-    sha = run.get("sha")
-    path = record["sample"]["path"]
-    if (
-        not isinstance(repository, str)
-        or not REPOSITORY_PATTERN.fullmatch(repository)
-        or not isinstance(sha, str)
-        or not SHA_PATTERN.fullmatch(sha)
-    ):
-        return None
-    return f"https://github.com/{repository}/tree/{sha}/{quote(path, safe='/')}"
 
 
 def diagnostic_excerpt(record: dict[str, Any]) -> str:

--- a/.github/scripts/test/test-collect-artifact-links.py
+++ b/.github/scripts/test/test-collect-artifact-links.py
@@ -19,7 +19,13 @@ class CollectArtifactLinksTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
-    def run_script(self, artifacts: list[dict[str, object]], repository: str = "example/repo", run_id: str = "42") -> dict[str, str]:
+    def run_script(
+        self,
+        artifacts: list[dict[str, object]],
+        repository: str = "example/repo",
+        run_id: str = "42",
+        run_attempt: str = "1",
+    ) -> dict[str, str]:
         artifacts_file = self.root / "artifacts.ndjson"
         artifacts_file.write_text("\n".join(json.dumps(artifact) for artifact in artifacts) + "\n", encoding="utf-8")
         output = self.root / "artifact-links.json"
@@ -33,6 +39,8 @@ class CollectArtifactLinksTests(unittest.TestCase):
                 repository,
                 "--run-id",
                 run_id,
+                "--run-attempt",
+                run_attempt,
                 "--output",
                 str(output),
             ],
@@ -88,6 +96,8 @@ class CollectArtifactLinksTests(unittest.TestCase):
                 "example/repo",
                 "--run-id",
                 "42",
+                "--run-attempt",
+                "1",
                 "--output",
                 str(output),
             ],

--- a/.github/scripts/test/test-collect-artifact-links.py
+++ b/.github/scripts/test/test-collect-artifact-links.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "collect-artifact-links.py"
+
+
+class CollectArtifactLinksTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_script(self, artifacts: list[dict[str, object]], repository: str = "example/repo", run_id: str = "42") -> dict[str, str]:
+        artifacts_file = self.root / "artifacts.ndjson"
+        artifacts_file.write_text("\n".join(json.dumps(artifact) for artifact in artifacts) + "\n", encoding="utf-8")
+        output = self.root / "artifact-links.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--artifacts-file",
+                str(artifacts_file),
+                "--repository",
+                repository,
+                "--run-id",
+                run_id,
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(output.read_text(encoding="utf-8"))
+
+    def test_maps_per_sample_artifact_name_to_artifact_page_url(self) -> None:
+        links = self.run_script(
+            [
+                {"name": "validation-pilot-python-quickstart-a", "id": 100},
+                {"name": "validation-pilot-csharp-quickstart-b", "id": 101},
+            ]
+        )
+        self.assertEqual(
+            links,
+            {
+                "python-quickstart-a": "https://github.com/example/repo/actions/runs/42/artifacts/100",
+                "csharp-quickstart-b": "https://github.com/example/repo/actions/runs/42/artifacts/101",
+            },
+        )
+
+    def test_excludes_manifest_and_combined_run_artifacts(self) -> None:
+        links = self.run_script(
+            [
+                {"name": "validation-pilot-manifest", "id": 1},
+                {"name": "validation-pilot-run-42-1", "id": 2},
+                {"name": "validation-pilot-python-quickstart-a", "id": 100},
+            ]
+        )
+        self.assertEqual(links, {"python-quickstart-a": "https://github.com/example/repo/actions/runs/42/artifacts/100"})
+
+    def test_ignores_unrelated_artifacts(self) -> None:
+        links = self.run_script([{"name": "some-other-artifact", "id": 5}])
+        self.assertEqual(links, {})
+
+    def test_ignores_malformed_lines(self) -> None:
+        artifacts_file = self.root / "artifacts.ndjson"
+        artifacts_file.write_text(
+            json.dumps({"name": "validation-pilot-python-quickstart-a", "id": 100}) + "\nnot json\n{}\n",
+            encoding="utf-8",
+        )
+        output = self.root / "artifact-links.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--artifacts-file",
+                str(artifacts_file),
+                "--repository",
+                "example/repo",
+                "--run-id",
+                "42",
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            json.loads(output.read_text(encoding="utf-8")),
+            {"python-quickstart-a": "https://github.com/example/repo/actions/runs/42/artifacts/100"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test/test-collect-job-links.py
+++ b/.github/scripts/test/test-collect-job-links.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "collect-job-links.py"
+
+
+class CollectJobLinksTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_script(self, jobs: list[dict[str, str]]) -> dict[str, str]:
+        jobs_file = self.root / "jobs.ndjson"
+        jobs_file.write_text("\n".join(json.dumps(job) for job in jobs) + "\n", encoding="utf-8")
+        output = self.root / "job-links.json"
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--jobs-file", str(jobs_file), "--output", str(output)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(output.read_text(encoding="utf-8"))
+
+    def test_matches_build_readiness_and_live_service_job_names(self) -> None:
+        links = self.run_script(
+            [
+                {
+                    "name": "build-readiness (python-quickstart-a, samples/python/quickstart/a, python, full-fleet)",
+                    "html_url": "https://github.com/example/repo/actions/runs/1/job/10",
+                },
+                {
+                    "name": "live-service (csharp-quickstart-b, samples/csharp/quickstart/b, csharp, full-fleet)",
+                    "html_url": "https://github.com/example/repo/actions/runs/1/job/11",
+                },
+            ]
+        )
+        self.assertEqual(
+            links,
+            {
+                "python-quickstart-a": "https://github.com/example/repo/actions/runs/1/job/10",
+                "csharp-quickstart-b": "https://github.com/example/repo/actions/runs/1/job/11",
+            },
+        )
+
+    def test_recovers_sample_id_from_truncated_job_name(self) -> None:
+        # GitHub truncates long matrix job display names, but the sample id
+        # (the matrix's first field) is always intact before the first comma.
+        links = self.run_script(
+            [
+                {
+                    "name": "build-readiness (python-hosted-agents-agent-framework-a2a-01, samples/python/hosted-agen...",
+                    "html_url": "https://github.com/example/repo/actions/runs/1/job/12",
+                },
+            ]
+        )
+        self.assertEqual(
+            links,
+            {"python-hosted-agents-agent-framework-a2a-01": "https://github.com/example/repo/actions/runs/1/job/12"},
+        )
+
+    def test_ignores_unrelated_jobs(self) -> None:
+        links = self.run_script(
+            [
+                {"name": "discover", "html_url": "https://github.com/example/repo/actions/runs/1/job/1"},
+                {"name": "completeness", "html_url": "https://github.com/example/repo/actions/runs/1/job/2"},
+                {"name": "publish-dashboard", "html_url": "https://github.com/example/repo/actions/runs/1/job/3"},
+            ]
+        )
+        self.assertEqual(links, {})
+
+    def test_ignores_malformed_lines(self) -> None:
+        links = self.run_script([{"name": "build-readiness (a, samples/a, python, full-fleet)", "html_url": "https://github.com/example/repo/actions/runs/1/job/1"}])
+        jobs_file = self.root / "jobs.ndjson"
+        jobs_file.write_text(jobs_file.read_text(encoding="utf-8") + "not json\n{}\n", encoding="utf-8")
+        output = self.root / "job-links.json"
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--jobs-file", str(jobs_file), "--output", str(output)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(output.read_text(encoding="utf-8")), links)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test/test-render-fallback-dashboard.py
+++ b/.github/scripts/test/test-render-fallback-dashboard.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "render-fallback-dashboard.py"
+
+
+class RenderFallbackDashboardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_script(self, run_url: str | None) -> str:
+        output = self.root / "index.html"
+        args = [sys.executable, str(SCRIPT), "--output", str(output)]
+        if run_url:
+            args.extend(["--run-url", run_url])
+        completed = subprocess.run(args, capture_output=True, text=True)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return output.read_text(encoding="utf-8")
+
+    def test_renders_a_page_with_a_link_to_the_run(self) -> None:
+        body = self.run_script("https://github.com/o/r/actions/runs/123")
+        self.assertIn("<html", body)
+        self.assertIn('href="https://github.com/o/r/actions/runs/123"', body)
+        self.assertIn("could not be retrieved", body)
+
+    def test_renders_a_page_even_without_a_run_url(self) -> None:
+        body = self.run_script(None)
+        self.assertIn("<html", body)
+        self.assertNotIn("href=", body)
+
+    def test_escapes_the_run_url(self) -> None:
+        body = self.run_script('https://example.com/"><script>alert(1)</script>')
+        self.assertNotIn("<script>alert(1)</script>", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test/test-render-fallback-dashboard.py
+++ b/.github/scripts/test/test-render-fallback-dashboard.py
@@ -32,6 +32,8 @@ class RenderFallbackDashboardTests(unittest.TestCase):
         self.assertIn("<html", body)
         self.assertIn('href="https://github.com/o/r/actions/runs/123"', body)
         self.assertIn("could not be retrieved", body)
+        self.assertIn("could not be retrieved or parsed", body)
+        self.assertIn("malformed validation data", body)
 
     def test_renders_a_page_even_without_a_run_url(self) -> None:
         body = self.run_script(None)

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -46,6 +46,7 @@ class DashboardTests(unittest.TestCase):
         job_links: dict[str, str] | None = None,
         artifact_links: dict[str, str] | None = None,
         codeowners: str | None = None,
+        codeowners_bytes: bytes | None = None,
     ) -> subprocess.CompletedProcess[str]:
         args = [
             sys.executable,
@@ -71,6 +72,10 @@ class DashboardTests(unittest.TestCase):
             codeowners_path = self.root / "CODEOWNERS"
             codeowners_path.write_text(codeowners, encoding="utf-8")
             args.extend(["--codeowners", str(codeowners_path)])
+        if codeowners_bytes is not None:
+            codeowners_path = self.root / "CODEOWNERS"
+            codeowners_path.write_bytes(codeowners_bytes)
+            args.extend(["--codeowners", str(codeowners_path)])
         return subprocess.run(args, capture_output=True, text=True)
 
     def write_result(
@@ -79,6 +84,7 @@ class DashboardTests(unittest.TestCase):
         outcome: str = "passed",
         diagnostic_text: str = "diagnostic\n",
         completed_stage: str = "build readiness validation",
+        run_overrides: dict[str, object] | None = None,
     ) -> None:
         manifest = json.loads(self.expected.read_text(encoding="utf-8"))
         sample_definition = next(
@@ -88,6 +94,17 @@ class DashboardTests(unittest.TestCase):
         sample_dir = self.results / sample_id
         sample_dir.mkdir()
         (sample_dir / "diagnostics.log").write_text(diagnostic_text, encoding="utf-8")
+        run: dict[str, object] = {
+            "repository": "example/repo",
+            "workflow": "validation pilot",
+            "run_id": "42",
+            "run_attempt": "1",
+            "sha": "abcdef0",
+            "ref": "refs/heads/main",
+            "started_at": "2026-08-10T19:22:00Z",
+        }
+        if run_overrides:
+            run.update(run_overrides)
         (sample_dir / "sample-result.json").write_text(
             json.dumps(
                 {
@@ -99,15 +116,7 @@ class DashboardTests(unittest.TestCase):
                     "diagnostic_reference": "diagnostics.log",
                     "artifact_reference": f"validation-pilot-{sample_id}",
                     "completed_at": "2026-08-10T19:22:33Z",
-                    "run": {
-                        "repository": "example/repo",
-                        "workflow": "validation pilot",
-                        "run_id": "42",
-                        "run_attempt": "1",
-                        "sha": "abcdef0",
-                        "ref": "refs/heads/main",
-                        "started_at": "2026-08-10T19:22:00Z",
-                    },
+                    "run": run,
                 }
             ),
             encoding="utf-8",
@@ -296,6 +305,19 @@ class DashboardTests(unittest.TestCase):
         self.assertNotIn("some-other/repo", body)
         self.assertNotIn("Diagnostics</a>", body)
 
+    def test_result_with_non_string_run_repository_renders_as_error_row(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure", run_overrides={"repository": ["example/repo"]})
+        completed = self.run_dashboard(
+            job_links={"b": "https://github.com/example/repo/actions/runs/42/job/999"},
+            artifact_links={"b": "https://github.com/example/repo/actions/runs/42/artifacts/555"},
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("banner banner-incomplete", body)
+        self.assertIn("⚠️ Infrastructure/error", body)
+        self.assertNotIn("Fix with Copilot", body)
+
     def test_failed_sample_offers_prefilled_copilot_issue(self) -> None:
         self.write_result(SAMPLE_A, "passed")
         self.write_result(SAMPLE_B, "sample failure", completed_stage="live-service validation")
@@ -421,6 +443,13 @@ class DashboardTests(unittest.TestCase):
     def test_missing_codeowners_file_falls_back_to_unowned(self) -> None:
         self.write_result(SAMPLE_A, "passed")
         completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">—</td>", body)
+
+    def test_corrupt_codeowners_file_falls_back_to_unowned(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard(codeowners_bytes=b"\xff\xfe\x00")
         self.assertEqual(completed.returncode, 0, completed.stderr)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn(">—</td>", body)

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -156,6 +156,7 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("banner banner-incomplete", body)
+        self.assertIn("most recent validation run", body)
         self.assertIn("not authoritative", body)
         self.assertIn(SAMPLE_B, body)
 
@@ -397,6 +398,16 @@ class DashboardTests(unittest.TestCase):
         # The nested entry names the same owner as the directory -- it must not
         # be listed twice.
         self.assertNotIn("@team-python, @team-python", body)
+
+    def test_repeated_primary_codeowner_is_deduplicated(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        codeowners = f"/{SAMPLE_A}/ @team-python @team-python\n"
+        completed = self.run_dashboard(codeowners=codeowners)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">@team-python</td>", body)
+        self.assertNotIn("@team-python, @team-python", body)
+        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn">@team-python (1)</button>', body)
 
     def test_codeowners_last_matching_entry_wins(self) -> None:
         self.write_result(SAMPLE_A, "passed")

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -163,6 +163,25 @@ class DashboardTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("banner banner-incomplete", body)
 
+    def test_multiple_orphaned_artifacts_render_as_distinct_rows(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        for directory in ("bad-one", "bad-two"):
+            bad = self.results / directory
+            bad.mkdir()
+            (bad / "sample-result.json").write_text("{", encoding="utf-8")
+
+        completed = self.run_dashboard()
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("invalid artifact: bad-one/sample-result.json", body)
+        self.assertIn("invalid artifact: bad-two/sample-result.json", body)
+        self.assertIn(
+            'data-filter-language="reporting" class="filter-btn">reporting (2)</button>',
+            body,
+        )
+
     def test_diagnostic_text_never_appears_on_the_public_page(self) -> None:
         self.write_result(SAMPLE_A, "passed")
         self.write_result(

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -138,6 +138,9 @@ class DashboardTests(unittest.TestCase):
         self.assertIn('data-sort-index="0"', body)
         self.assertIn('data-sort-index="2"', body)
         self.assertIn("<script>", body)
+        self.assertIn(">Validation<", body)
+        self.assertIn(">Build check</td>", body)
+        self.assertIn('title="build readiness validation"', body)
 
     def test_missing_result_is_shown_and_still_exits_zero_with_banner(self) -> None:
         # Sample "b" is in the manifest (i.e. discovery found its sample.yaml,
@@ -307,7 +310,7 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(query["assignees"], ["copilot-swe-agent[bot]"])
         self.assertEqual(query["title"], [f"Fix validation failure: {SAMPLE_B}"])
         self.assertIn(SAMPLE_B, query["body"][0])
-        self.assertIn("live-service validation", query["body"][0])
+        self.assertIn("Live run", query["body"][0])
         self.assertIn("https://github.com/example/repo/actions/runs/42/job/999", query["body"][0])
         self.assertIn("https://github.com/example/repo/actions/runs/42/artifacts/555", query["body"][0])
 

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import html
+import re
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "render-validation-dashboard.py"
@@ -266,6 +269,35 @@ class DashboardTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertNotIn("some-other/repo", body)
         self.assertNotIn("Diagnostics</a>", body)
+
+    def test_failed_sample_offers_prefilled_copilot_issue(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure", completed_stage="live-service validation")
+        completed = self.run_dashboard(
+            job_links={"b": "https://github.com/example/repo/actions/runs/42/job/999"},
+            artifact_links={"b": "https://github.com/example/repo/actions/runs/42/artifacts/555"},
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        match = re.search(r'<a href="([^"]+)" class="copilot-link">Fix with Copilot ↗</a>', body)
+        self.assertIsNotNone(match)
+        issue_url = html.unescape(match.group(1))
+        parsed = urlparse(issue_url)
+        query = parse_qs(parsed.query)
+        self.assertEqual(parsed.path, "/example/repo/issues/new")
+        self.assertEqual(query["assignees"], ["copilot-swe-agent[bot]"])
+        self.assertEqual(query["title"], [f"Fix validation failure: {SAMPLE_B}"])
+        self.assertIn(SAMPLE_B, query["body"][0])
+        self.assertIn("live-service validation", query["body"][0])
+        self.assertIn("https://github.com/example/repo/actions/runs/42/job/999", query["body"][0])
+        self.assertIn("https://github.com/example/repo/actions/runs/42/artifacts/555", query["body"][0])
+
+    def test_passed_sample_does_not_offer_copilot_issue(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertNotIn("Fix with Copilot", body)
 
     def test_language_filter_row_lists_each_distinct_language(self) -> None:
         self.write_result(SAMPLE_A, "passed")

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -127,6 +127,8 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(body.count("<table"), 1)
         self.assertIn("✅ Passed (1)", body)
         self.assertIn("❌ Sample failure (1)", body)
+        self.assertIn('<details class="filter-panel">', body)
+        self.assertIn('<summary><strong>Filters</strong><span id="filter-summary">Showing all samples</span></summary>', body)
         self.assertIn('data-filter-outcome="all"', body)
         self.assertIn('data-filter-outcome="passed"', body)
         self.assertIn("Workflow run", body)
@@ -141,6 +143,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(">Validation<", body)
         self.assertIn(">Build check</td>", body)
         self.assertIn('title="build readiness validation"', body)
+        self.assertIn('data-validation="build readiness validation"', body)
 
     def test_missing_result_is_shown_and_still_exits_zero_with_banner(self) -> None:
         # Sample "b" is in the manifest (i.e. discovery found its sample.yaml,
@@ -334,6 +337,27 @@ class DashboardTests(unittest.TestCase):
         # Rows carry a data-language attribute so the client-side filter can match on it.
         self.assertIn('data-language="python"', body)
         self.assertIn('data-language="csharp"', body)
+
+    def test_validation_filter_row_lists_each_distinct_validation_label(self) -> None:
+        self.write_result(SAMPLE_A, "passed", completed_stage="build readiness validation")
+        self.write_result(SAMPLE_B, "sample failure", completed_stage="live-service validation")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn('<div class="filter-group"><strong>Validation</strong>', body)
+        self.assertIn('data-filter-validation="all" class="active">All (2)</button>', body)
+        self.assertIn(
+            'data-filter-validation="build readiness validation" class="filter-btn">Build check (1)</button>',
+            body,
+        )
+        self.assertIn(
+            'data-filter-validation="live-service validation" class="filter-btn">Live run (1)</button>',
+            body,
+        )
+        self.assertIn('data-validation="build readiness validation"', body)
+        self.assertIn('data-validation="live-service validation"', body)
+        self.assertIn('data: "validation", label: "Validation"', body)
+        self.assertIn('summary.textContent = "Showing " + visibleCount + " of " + total + " samples"', body)
 
     def test_codeowner_column_combines_directory_owner_and_nested_file_owner(self) -> None:
         self.write_result(SAMPLE_A, "passed")

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "render-validation-dashboard.py"
+SAMPLE_A = "samples/python/quickstart/a"
+SAMPLE_B = "samples/csharp/quickstart/b"
+
+
+class DashboardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.results = self.root / "results"
+        self.results.mkdir()
+        self.expected = self.root / "expected.json"
+        self.expected.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "samples": [
+                        {"id": "a", "path": SAMPLE_A, "language": "python", "shape": "quickstart"},
+                        {"id": "b", "path": SAMPLE_B, "language": "csharp", "shape": "quickstart"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.output = self.root / "index.html"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_dashboard(
+        self,
+        job_links: dict[str, str] | None = None,
+        artifact_links: dict[str, str] | None = None,
+        codeowners: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        args = [
+            sys.executable,
+            str(SCRIPT),
+            "--results-dir",
+            str(self.results),
+            "--expected-samples",
+            str(self.expected),
+            "--output",
+            str(self.output),
+            "--run-url",
+            "https://github.com/example/repo/actions/runs/42",
+        ]
+        if job_links is not None:
+            job_links_path = self.root / "job-links.json"
+            job_links_path.write_text(json.dumps(job_links), encoding="utf-8")
+            args.extend(["--job-links", str(job_links_path)])
+        if artifact_links is not None:
+            artifact_links_path = self.root / "artifact-links.json"
+            artifact_links_path.write_text(json.dumps(artifact_links), encoding="utf-8")
+            args.extend(["--artifact-links", str(artifact_links_path)])
+        if codeowners is not None:
+            codeowners_path = self.root / "CODEOWNERS"
+            codeowners_path.write_text(codeowners, encoding="utf-8")
+            args.extend(["--codeowners", str(codeowners_path)])
+        return subprocess.run(args, capture_output=True, text=True)
+
+    def write_result(
+        self,
+        sample: str,
+        outcome: str = "passed",
+        diagnostic_text: str = "diagnostic\n",
+        completed_stage: str = "build readiness validation",
+    ) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        sample_definition = next(
+            value for value in manifest["samples"] if value["path"] == sample
+        )
+        sample_id = sample_definition["id"]
+        sample_dir = self.results / sample_id
+        sample_dir.mkdir()
+        (sample_dir / "diagnostics.log").write_text(diagnostic_text, encoding="utf-8")
+        (sample_dir / "sample-result.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": manifest["schema_version"],
+                    "sample": sample_definition,
+                    "outcome": outcome,
+                    "completed_stage": completed_stage,
+                    "duration_seconds": 12.5,
+                    "diagnostic_reference": "diagnostics.log",
+                    "artifact_reference": f"validation-pilot-{sample_id}",
+                    "completed_at": "2026-08-10T19:22:33Z",
+                    "run": {
+                        "repository": "example/repo",
+                        "workflow": "validation pilot",
+                        "run_id": "42",
+                        "run_attempt": "1",
+                        "sha": "abcdef0",
+                        "ref": "refs/heads/main",
+                        "started_at": "2026-08-10T19:22:00Z",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_renders_every_manifest_sample_with_no_banner_when_complete(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("<html", body)
+        self.assertIn(SAMPLE_A, body)
+        self.assertIn(SAMPLE_B, body)
+        self.assertIn('<table id="results">', body)
+        # Only one table now -- no more per-outcome sections.
+        self.assertEqual(body.count("<table"), 1)
+        self.assertIn("✅ Passed (1)", body)
+        self.assertIn("❌ Sample failure (1)", body)
+        self.assertIn('data-filter-outcome="all"', body)
+        self.assertIn('data-filter-outcome="passed"', body)
+        self.assertIn("Workflow run", body)
+        self.assertNotIn("not authoritative", body)
+        # Status badges link to the workflow run so a reader can jump
+        # straight from a row to the run that produced it.
+        self.assertIn('<a href="https://github.com/example/repo/actions/runs/42"><span class="badge', body)
+        # Column headers are click-to-sort.
+        self.assertIn('data-sort-index="0"', body)
+        self.assertIn('data-sort-index="2"', body)
+        self.assertIn("<script>", body)
+
+    def test_missing_result_is_shown_and_still_exits_zero_with_banner(self) -> None:
+        # Sample "b" is in the manifest (i.e. discovery found its sample.yaml,
+        # exactly like a newly added sample would be) but never produced a
+        # result -- e.g. the fleet run failed to complete. The dashboard must
+        # still publish (exit 0) so a broken run doesn't leave a stale page
+        # looking like current status, and must flag itself as unauthoritative.
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("banner banner-incomplete", body)
+        self.assertIn("not authoritative", body)
+        self.assertIn(SAMPLE_B, body)
+
+    def test_malformed_artifact_is_shown_and_still_exits_zero(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        sample_dir = self.results / "b"
+        sample_dir.mkdir()
+        (sample_dir / "sample-result.json").write_text("not json", encoding="utf-8")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("banner banner-incomplete", body)
+
+    def test_diagnostic_text_never_appears_on_the_public_page(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(
+            SAMPLE_B,
+            "sample failure",
+            diagnostic_text="FAIL: super-secret-marker-should-not-be-published\n",
+        )
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertNotIn("super-secret-marker-should-not-be-published", body)
+
+    def test_html_special_characters_in_sample_fields_are_escaped(self) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        manifest["samples"][1]["path"] = 'samples/csharp/quickstart/<script>alert(1)</script>'
+        self.expected.write_text(json.dumps(manifest), encoding="utf-8")
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(
+            'samples/csharp/quickstart/<script>alert(1)</script>',
+            "sample failure",
+            completed_stage='"><img src=x onerror=alert(1)>',
+        )
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertNotIn("<script>alert(1)</script>", body)
+        self.assertNotIn("<img src=x onerror=alert(1)>", body)
+        self.assertIn("&lt;script&gt;", body)
+
+    def test_sample_links_to_validated_commit(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("https://github.com/example/repo/tree/abcdef0", body)
+        self.assertIn("https://github.com/example/repo/commit/abcdef0", body)
+
+    def test_status_links_to_per_sample_job_when_job_links_provided(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard(
+            job_links={
+                "b": "https://github.com/example/repo/actions/runs/42/job/999",
+            }
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        # Sample "b" has a specific job link -- its badge should go straight
+        # to that job page, not the generic run-overview link.
+        self.assertIn(
+            '<a href="https://github.com/example/repo/actions/runs/42/job/999">'
+            '<span class="badge failed">',
+            body,
+        )
+        # Sample "a" has no entry in the map, so it falls back to the run link.
+        self.assertIn(
+            '<a href="https://github.com/example/repo/actions/runs/42">'
+            '<span class="badge passed">',
+            body,
+        )
+
+    def test_job_links_with_wrong_repository_are_ignored(self) -> None:
+        # A job-links entry that doesn't match this run's own repository
+        # must never be trusted -- fall back to the run link instead of
+        # linking off-run.
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard(
+            job_links={"a": "https://github.com/some-other/repo/actions/runs/1/job/1"}
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertNotIn("some-other/repo", body)
+        self.assertIn(
+            '<a href="https://github.com/example/repo/actions/runs/42">'
+            '<span class="badge passed">',
+            body,
+        )
+
+    def test_artifact_column_links_when_provided_and_shows_placeholder_otherwise(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard(
+            artifact_links={"a": "https://github.com/example/repo/actions/runs/42/artifacts/555"}
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(
+            '<a href="https://github.com/example/repo/actions/runs/42/artifacts/555" class="artifact-link">',
+            body,
+        )
+        self.assertIn('class="icon-download"', body)
+        self.assertIn(">Diagnostics</a>", body)
+        # Sample "b" has no artifact link -- shown as a plain placeholder, not a broken link.
+        self.assertIn(">—</td>", body)
+        self.assertIn(">Artifact<", body)
+
+    def test_artifact_links_with_wrong_repository_are_ignored(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard(
+            artifact_links={"a": "https://github.com/some-other/repo/actions/runs/1/artifacts/1"}
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertNotIn("some-other/repo", body)
+        self.assertNotIn("Diagnostics</a>", body)
+
+    def test_language_filter_row_lists_each_distinct_language(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn('<div id="language-filters" class="filters">', body)
+        self.assertIn('data-filter-language="all" class="active">All (2)</button>', body)
+        self.assertIn('data-filter-language="python" class="filter-btn">python (1)</button>', body)
+        self.assertIn('data-filter-language="csharp" class="filter-btn">csharp (1)</button>', body)
+        # Rows carry a data-language attribute so the client-side filter can match on it.
+        self.assertIn('data-language="python"', body)
+        self.assertIn('data-language="csharp"', body)
+
+    def test_codeowner_column_combines_directory_owner_and_nested_file_owner(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        codeowners = (
+            "# comment line, ignored\n"
+            "\n"
+            f"/{SAMPLE_A}/ @team-python\n"
+            # A file-specific entry nested inside sample b's directory (e.g. a docs
+            # team owning one file referenced from docs) is a real reviewer for
+            # that sample too -- it should be unioned in, not discarded, even
+            # though sample b has no directory-level CODEOWNERS entry of its own.
+            f"/{SAMPLE_B}/inner_file.py @some-doc-owner\n"
+        )
+        completed = self.run_dashboard(codeowners=codeowners)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">Codeowner<", body)
+        self.assertIn('data-codeowner="@team-python"', body)
+        self.assertIn(">@team-python</td>", body)
+        # Sample b has no directory-level entry, but does have a nested file
+        # owner, so it shows that owner rather than falling back to "—".
+        self.assertIn('data-codeowner="@some-doc-owner"', body)
+        self.assertIn(">@some-doc-owner</td>", body)
+        self.assertIn('data-filter-codeowner="all" class="active">All (2)</button>', body)
+        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn">@team-python (1)</button>', body)
+        self.assertIn('data-filter-codeowner="@some-doc-owner" class="filter-btn">@some-doc-owner (1)</button>', body)
+        self.assertNotIn("Unowned (", body)
+
+    def test_codeowner_directory_owner_and_nested_file_owner_are_deduplicated(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        codeowners = f"/{SAMPLE_A}/ @team-python\n/{SAMPLE_A}/inner_file.py @team-python\n"
+        completed = self.run_dashboard(codeowners=codeowners)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">@team-python</td>", body)
+        # The nested entry names the same owner as the directory -- it must not
+        # be listed twice.
+        self.assertNotIn("@team-python, @team-python", body)
+
+    def test_codeowners_last_matching_entry_wins(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        codeowners = f"/{SAMPLE_A}/ @team-general\n/{SAMPLE_A}/ @team-specific\n"
+        completed = self.run_dashboard(codeowners=codeowners)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">@team-specific</td>", body)
+        self.assertNotIn(">@team-general</td>", body)
+
+    def test_missing_codeowners_file_falls_back_to_unowned(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        completed = self.run_dashboard()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn(">—</td>", body)
+
+    def test_sample_with_no_matching_codeowners_entry_counts_as_unowned(self) -> None:
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure")
+        completed = self.run_dashboard(codeowners=f"/{SAMPLE_A}/ @team-python\n")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn('data-codeowner=""', body)
+        self.assertIn('data-filter-codeowner="" class="filter-btn">Unowned (1)</button>', body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test/test-render-validation-dashboard.py
+++ b/.github/scripts/test/test-render-validation-dashboard.py
@@ -185,7 +185,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn("invalid artifact: bad-one/sample-result.json", body)
         self.assertIn("invalid artifact: bad-two/sample-result.json", body)
         self.assertIn(
-            'data-filter-language="reporting" class="filter-btn">reporting (2)</button>',
+            'data-filter-language="reporting" class="filter-btn" aria-pressed="false">reporting (2)</button>',
             body,
         )
 
@@ -332,9 +332,9 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn('<div id="language-filters" class="filters">', body)
-        self.assertIn('data-filter-language="all" class="active">All (2)</button>', body)
-        self.assertIn('data-filter-language="python" class="filter-btn">python (1)</button>', body)
-        self.assertIn('data-filter-language="csharp" class="filter-btn">csharp (1)</button>', body)
+        self.assertIn('data-filter-language="all" class="active" aria-pressed="true">All (2)</button>', body)
+        self.assertIn('data-filter-language="python" class="filter-btn" aria-pressed="false">python (1)</button>', body)
+        self.assertIn('data-filter-language="csharp" class="filter-btn" aria-pressed="false">csharp (1)</button>', body)
         # Rows carry a data-language attribute so the client-side filter can match on it.
         self.assertIn('data-language="python"', body)
         self.assertIn('data-language="csharp"', body)
@@ -346,13 +346,13 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn('<div class="filter-group"><strong>Validation</strong>', body)
-        self.assertIn('data-filter-validation="all" class="active">All (2)</button>', body)
+        self.assertIn('data-filter-validation="all" class="active" aria-pressed="true">All (2)</button>', body)
         self.assertIn(
-            'data-filter-validation="build readiness validation" class="filter-btn">Build check (1)</button>',
+            'data-filter-validation="build readiness validation" class="filter-btn" aria-pressed="false">Build check (1)</button>',
             body,
         )
         self.assertIn(
-            'data-filter-validation="live-service validation" class="filter-btn">Live run (1)</button>',
+            'data-filter-validation="live-service validation" class="filter-btn" aria-pressed="false">Live run (1)</button>',
             body,
         )
         self.assertIn('data-validation="build readiness validation"', body)
@@ -383,9 +383,9 @@ class DashboardTests(unittest.TestCase):
         # owner, so it shows that owner rather than falling back to "—".
         self.assertIn('data-codeowner="@some-doc-owner"', body)
         self.assertIn(">@some-doc-owner</td>", body)
-        self.assertIn('data-filter-codeowner="all" class="active">All (2)</button>', body)
-        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn">@team-python (1)</button>', body)
-        self.assertIn('data-filter-codeowner="@some-doc-owner" class="filter-btn">@some-doc-owner (1)</button>', body)
+        self.assertIn('data-filter-codeowner="all" class="active" aria-pressed="true">All (2)</button>', body)
+        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn" aria-pressed="false">@team-python (1)</button>', body)
+        self.assertIn('data-filter-codeowner="@some-doc-owner" class="filter-btn" aria-pressed="false">@some-doc-owner (1)</button>', body)
         self.assertNotIn("Unowned (", body)
 
     def test_codeowner_directory_owner_and_nested_file_owner_are_deduplicated(self) -> None:
@@ -407,7 +407,7 @@ class DashboardTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn(">@team-python</td>", body)
         self.assertNotIn("@team-python, @team-python", body)
-        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn">@team-python (1)</button>', body)
+        self.assertIn('data-filter-codeowner="@team-python" class="filter-btn" aria-pressed="false">@team-python (1)</button>', body)
 
     def test_codeowners_last_matching_entry_wins(self) -> None:
         self.write_result(SAMPLE_A, "passed")
@@ -432,7 +432,7 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn('data-codeowner=""', body)
-        self.assertIn('data-filter-codeowner="" class="filter-btn">Unowned (1)</button>', body)
+        self.assertIn('data-filter-codeowner="" class="filter-btn" aria-pressed="false">Unowned (1)</button>', body)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -244,6 +244,17 @@ class ReportTests(unittest.TestCase):
         self.assertIn("`<invalid artifact: bad/sample-result.json>`", body)
         self.assertNotIn("tree/abcdef0/%3Cinvalid%20artifact", body)
 
+    def test_corrupt_run_metadata_falls_back_to_empty_metadata(self) -> None:
+        (self.results / "run-metadata.json").write_bytes(b"\xff\xfe\x00")
+        self.write_result(SAMPLE_A)
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("expected result artifact is missing for b", body)
+        self.assertNotIn("UnicodeDecodeError", completed.stderr)
+
     def test_invalid_result_for_a_known_sample_does_not_also_report_it_missing(self) -> None:
         # A result artifact that identifies a real expected sample but fails
         # validation for some other reason (here, an unsupported outcome)

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -190,8 +190,21 @@ class ReportTests(unittest.TestCase):
         completed = self.run_report()
         self.assertEqual(completed.returncode, 1)
         body = self.output.read_text(encoding="utf-8")
-        self.assertIn("invalid artifact: sample-result.json", body)
+        self.assertIn("invalid artifact: bad/sample-result.json", body)
         self.assertIn("⚠️ Infrastructure/error", body)
+
+    def test_multiple_orphaned_artifacts_keep_unique_identities(self) -> None:
+        for directory in ("bad-one", "bad-two"):
+            bad = self.results / directory
+            bad.mkdir()
+            (bad / "sample-result.json").write_text("{", encoding="utf-8")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("invalid artifact: bad-one/sample-result.json", body)
+        self.assertIn("invalid artifact: bad-two/sample-result.json", body)
 
     def test_invalid_result_for_a_known_sample_does_not_also_report_it_missing(self) -> None:
         # A result artifact that identifies a real expected sample but fails

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -301,6 +301,21 @@ class ReportTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("abcdef0", body)
 
+    def test_run_shape_error_reports_missing_and_extra_fields(self) -> None:
+        self.write_result(SAMPLE_A)
+        result_path = self.results / "a" / "sample-result.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        del result["run"]["ref"]
+        result["run"]["unexpected"] = "value"
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("missing fields: ['ref']", body)
+        self.assertIn("extra fields: ['unexpected']", body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -206,6 +206,44 @@ class ReportTests(unittest.TestCase):
         self.assertIn("invalid artifact: bad-one/sample-result.json", body)
         self.assertIn("invalid artifact: bad-two/sample-result.json", body)
 
+    def test_corrupt_utf8_artifact_publishes_error_row_and_fails(self) -> None:
+        bad = self.results / "bad-utf8"
+        bad.mkdir()
+        (bad / "sample-result.json").write_bytes(b"\xff\xfe\x00")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("invalid artifact: bad-utf8/sample-result.json", body)
+        self.assertIn("not valid UTF-8", body)
+
+    def test_orphaned_artifact_with_run_metadata_does_not_link_to_synthetic_path(self) -> None:
+        (self.results / "run-metadata.json").write_text(
+            json.dumps(
+                {
+                    "repository": "example/repo",
+                    "workflow": "validation pilot",
+                    "run_id": "42",
+                    "run_attempt": "1",
+                    "sha": "abcdef0",
+                    "ref": "refs/heads/main",
+                    "started_at": "2026-08-10T19:22:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        bad = self.results / "bad"
+        bad.mkdir()
+        (bad / "sample-result.json").write_text("{", encoding="utf-8")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("`<invalid artifact: bad/sample-result.json>`", body)
+        self.assertNotIn("tree/abcdef0/%3Cinvalid%20artifact", body)
+
     def test_invalid_result_for_a_known_sample_does_not_also_report_it_missing(self) -> None:
         # A result artifact that identifies a real expected sample but fails
         # validation for some other reason (here, an unsupported outcome)
@@ -287,6 +325,59 @@ class ReportTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 1)
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("⚠️ Infrastructure/error", body)
+
+    def test_non_finite_duration_is_reported_as_error_not_valid_result(self) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        sample_definition = next(value for value in manifest["samples"] if value["path"] == SAMPLE_A)
+        sample_dir = self.results / sample_definition["id"]
+        sample_dir.mkdir()
+        (sample_dir / "diagnostics.log").write_text("diagnostic\n", encoding="utf-8")
+        (sample_dir / "sample-result.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": manifest["schema_version"],
+                    "sample": sample_definition,
+                    "outcome": "passed",
+                    "completed_stage": "build readiness validation",
+                    "duration_seconds": float("nan"),
+                    "diagnostic_reference": "diagnostics.log",
+                    "artifact_reference": f"validation-pilot-{sample_definition['id']}",
+                    "completed_at": "2026-08-10T19:22:33Z",
+                    "run": {
+                        "repository": "example/repo",
+                        "workflow": "validation pilot",
+                        "run_id": "42",
+                        "run_attempt": "1",
+                        "sha": "abcdef0",
+                        "ref": "refs/heads/main",
+                        "started_at": "2026-08-10T19:22:00Z",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.write_result(SAMPLE_B)
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("duration_seconds must be a finite non-negative number", body)
+        self.assertNotIn("nans", body)
+
+    def test_result_schema_must_match_manifest_schema(self) -> None:
+        self.write_result(SAMPLE_A)
+        result_path = self.results / "a" / "sample-result.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["schema_version"] = 1
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+        self.write_result(SAMPLE_B)
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("result schema_version 1 does not match manifest schema_version 2", body)
 
     def test_all_samples_missing_still_links_validated_commit_from_run_metadata(self) -> None:
         # When every expected sample is missing, there is no per-sample `run`

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -379,6 +379,30 @@ class ReportTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("result schema_version 1 does not match manifest schema_version 2", body)
 
+    def test_manifest_schema_version_boolean_is_rejected(self) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        manifest["schema_version"] = True
+        self.expected.write_text(json.dumps(manifest), encoding="utf-8")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("sample manifest must contain a non-empty samples array", completed.stderr)
+
+    def test_result_schema_version_float_is_rejected(self) -> None:
+        self.write_result(SAMPLE_A)
+        self.write_result(SAMPLE_B)
+        result_path = self.results / "a" / "sample-result.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["schema_version"] = 2.0
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+
+        completed = self.run_report()
+
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("result must be a supported schema object", body)
+
     def test_all_samples_missing_still_links_validated_commit_from_run_metadata(self) -> None:
         # When every expected sample is missing, there is no per-sample `run`
         # block to draw the validated-commit link from -- but the

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -193,6 +193,114 @@ class ReportTests(unittest.TestCase):
         self.assertIn("invalid artifact: sample-result.json", body)
         self.assertIn("⚠️ Infrastructure/error", body)
 
+    def test_invalid_result_for_a_known_sample_does_not_also_report_it_missing(self) -> None:
+        # A result artifact that identifies a real expected sample but fails
+        # validation for some other reason (here, an unsupported outcome)
+        # should produce exactly one error row for that sample -- not both an
+        # "invalid artifact" row and a separate "missing" row for the same
+        # sample.
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        sample_definition = next(value for value in manifest["samples"] if value["path"] == SAMPLE_A)
+        sample_dir = self.results / sample_definition["id"]
+        sample_dir.mkdir()
+        (sample_dir / "diagnostics.log").write_text("diagnostic\n", encoding="utf-8")
+        (sample_dir / "sample-result.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": manifest["schema_version"],
+                    "sample": sample_definition,
+                    "outcome": "not-a-real-outcome",
+                    "completed_stage": "build readiness validation",
+                    "duration_seconds": 12.5,
+                    "diagnostic_reference": "diagnostics.log",
+                    "artifact_reference": f"validation-pilot-{sample_definition['id']}",
+                    "completed_at": "2026-08-10T19:22:33Z",
+                    "run": {
+                        "repository": "example/repo",
+                        "workflow": "validation pilot",
+                        "run_id": "42",
+                        "run_attempt": "1",
+                        "sha": "abcdef0",
+                        "ref": "refs/heads/main",
+                        "started_at": "2026-08-10T19:22:00Z",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.write_result(SAMPLE_B)
+        completed = self.run_report()
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertEqual(body.count(SAMPLE_A), 1, body)
+        self.assertNotIn("expected result artifact is missing for a", body)
+
+    def test_outcome_of_wrong_json_type_is_reported_as_error_not_a_crash(self) -> None:
+        # A malformed artifact whose outcome is e.g. a list rather than a
+        # string must not crash normalization with an uncaught TypeError --
+        # it should become an infrastructure/error row like any other
+        # malformed artifact.
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        sample_definition = next(value for value in manifest["samples"] if value["path"] == SAMPLE_A)
+        sample_dir = self.results / sample_definition["id"]
+        sample_dir.mkdir()
+        (sample_dir / "diagnostics.log").write_text("diagnostic\n", encoding="utf-8")
+        (sample_dir / "sample-result.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": manifest["schema_version"],
+                    "sample": sample_definition,
+                    "outcome": ["passed"],
+                    "completed_stage": "build readiness validation",
+                    "duration_seconds": 12.5,
+                    "diagnostic_reference": "diagnostics.log",
+                    "artifact_reference": f"validation-pilot-{sample_definition['id']}",
+                    "completed_at": "2026-08-10T19:22:33Z",
+                    "run": {
+                        "repository": "example/repo",
+                        "workflow": "validation pilot",
+                        "run_id": "42",
+                        "run_attempt": "1",
+                        "sha": "abcdef0",
+                        "ref": "refs/heads/main",
+                        "started_at": "2026-08-10T19:22:00Z",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.write_result(SAMPLE_B)
+        completed = self.run_report()
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("⚠️ Infrastructure/error", body)
+
+    def test_all_samples_missing_still_links_validated_commit_from_run_metadata(self) -> None:
+        # When every expected sample is missing, there is no per-sample `run`
+        # block to draw the validated-commit link from -- but the
+        # completeness job always persists a run-metadata.json alongside the
+        # per-sample result directories, and that should be used as a
+        # fallback so the report doesn't lose run/commit context entirely.
+        (self.results / "run-metadata.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "repository": "example/repo",
+                    "workflow": "validation pilot",
+                    "run_id": "42",
+                    "run_attempt": "1",
+                    "sha": "abcdef0",
+                    "ref": "refs/heads/main",
+                    "completed_at": "2026-08-10T19:22:33Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = self.run_report()
+        self.assertEqual(completed.returncode, 1)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("abcdef0", body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -28,6 +28,23 @@ DISCOVERY_SPEC.loader.exec_module(validation_discovery)
 
 
 class ValidationPilotTests(unittest.TestCase):
+    def test_discovery_rejects_unsafe_or_reserved_sample_ids(self) -> None:
+        invalid_ids = (
+            ("python-has,comma", "must contain only"),
+            ("manifest", "collides with a reserved"),
+            ("run-123-4", "collides with a reserved"),
+        )
+        for identifier, message in invalid_ids:
+            with self.subTest(identifier=identifier):
+                with self.assertRaisesRegex(
+                    validation_discovery.DiscoveryError,
+                    message,
+                ):
+                    validation_discovery.validate_sample_id(
+                        identifier,
+                        f"samples/python/{identifier}",
+                    )
+
     def test_workflow_calls_report_after_completeness(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("  report:", workflow)
@@ -36,6 +53,27 @@ class ValidationPilotTests(unittest.TestCase):
         self.assertIn("uses: ./.github/workflows/validation-report.yml", workflow)
         self.assertIn(
             "results-artifact: validation-pilot-run-${{ github.run_id }}-${{ github.run_attempt }}",
+            workflow,
+        )
+
+    def test_dashboard_publication_falls_back_after_optional_handoff_failures(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        publish_dashboard = workflow.split("  publish-dashboard:", 1)[1]
+        self.assertEqual(publish_dashboard.count("continue-on-error: true"), 3)
+        self.assertIn(
+            'if [ "${{ steps.download.outcome }}" = "success" ] && \\\n'
+            "            python .github/scripts/render-validation-dashboard.py",
+            publish_dashboard,
+        )
+        self.assertIn(
+            "python .github/scripts/render-fallback-dashboard.py",
+            publish_dashboard,
+        )
+
+    def test_dashboard_harness_runs_fallback_renderer_tests(self) -> None:
+        workflow = SELFTEST_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "python .github/scripts/test/test-render-fallback-dashboard.py",
             workflow,
         )
 

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -11,6 +11,7 @@ Presentation (Markdown vs. HTML, escaping, layout) stays in each renderer.
 from __future__ import annotations
 
 import json
+import math
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,6 +44,12 @@ class ContractError(ValueError):
     pass
 
 
+class ExpectedSamples(list[dict[str, str]]):
+    def __init__(self, samples: list[dict[str, str]], schema_version: int) -> None:
+        super().__init__(samples)
+        self.schema_version = schema_version
+
+
 def _in(value: Any, container: Any) -> bool:
     """Membership test that treats an unhashable value as simply absent.
 
@@ -64,6 +71,8 @@ def load_json(path: Path, label: str) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise ContractError(f"{label} not found: {path}") from exc
+    except UnicodeError as exc:
+        raise ContractError(f"{label} is not valid UTF-8: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise ContractError(f"{label} is not valid JSON: {exc}") from exc
 
@@ -91,7 +100,7 @@ def sample_identity(value: Any, field: str) -> dict[str, str]:
     return {key: value[key] for key in keys}
 
 
-def load_expected(path: Path) -> list[dict[str, str]]:
+def load_expected(path: Path) -> ExpectedSamples:
     payload = load_json(path, "sample manifest")
     if (
         not isinstance(payload, dict)
@@ -104,10 +113,10 @@ def load_expected(path: Path) -> list[dict[str, str]]:
     ids = [value["id"] for value in samples]
     if ids != sorted(set(ids)):
         raise ContractError("manifest samples must be sorted and unique by id")
-    return samples
+    return ExpectedSamples(samples, payload["schema_version"])
 
 
-def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
+def load_record(path: Path, expected: dict[str, str], expected_schema_version: int | None = None) -> dict[str, Any]:
     value = load_json(path, f"result artifact {path}")
     if (
         not isinstance(value, dict)
@@ -118,6 +127,10 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     missing = REQUIRED - value.keys()
     if missing:
         raise ContractError(f"result is missing fields: {sorted(missing)}")
+    if expected_schema_version is not None and value["schema_version"] != expected_schema_version:
+        raise ContractError(
+            f"result schema_version {value['schema_version']!r} does not match manifest schema_version {expected_schema_version!r}"
+        )
     sample = sample_identity(value["sample"], "result sample")
     if sample != expected:
         raise ContractError(f"sample identity does not match manifest: {sample['id']}")
@@ -125,8 +138,13 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
         raise ContractError(f"unsupported outcome: {value['outcome']!r}")
     if not isinstance(value["completed_stage"], str) or not value["completed_stage"]:
         raise ContractError("completed_stage must be non-empty")
-    if not isinstance(value["duration_seconds"], (int, float)) or isinstance(value["duration_seconds"], bool) or value["duration_seconds"] < 0:
-        raise ContractError("duration_seconds must be non-negative")
+    if (
+        not isinstance(value["duration_seconds"], (int, float))
+        or isinstance(value["duration_seconds"], bool)
+        or not math.isfinite(value["duration_seconds"])
+        or value["duration_seconds"] < 0
+    ):
+        raise ContractError("duration_seconds must be a finite non-negative number")
     timestamp(value["completed_at"], "completed_at")
     run = value["run"]
     if not isinstance(run, dict):
@@ -200,6 +218,7 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
     if not results_dir.is_dir():
         raise ContractError(f"result artifact directory not found: {results_dir}")
     expected_by_id = {value["id"]: value for value in expected}
+    expected_schema_version = getattr(expected, "schema_version", None)
     records: dict[str, dict[str, Any]] = {}
     incomplete = False
     run_fallback = _load_run_fallback(results_dir)
@@ -213,7 +232,7 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
                 raise ContractError(f"unexpected sample id: {sample_id!r}")
             if sample_id in records:
                 raise ContractError(f"duplicate result artifact for {sample_id}")
-            record = load_record(path, expected_by_id[sample_id])
+            record = load_record(path, expected_by_id[sample_id], expected_schema_version)
             records[sample_id] = record
         except ContractError as exc:
             incomplete = True
@@ -264,6 +283,9 @@ def sample_url(record: dict[str, Any]) -> str | None:
         or not REPOSITORY_PATTERN.fullmatch(repository)
         or not isinstance(sha, str)
         or not SHA_PATTERN.fullmatch(sha)
+        or not isinstance(path, str)
+        or not path.startswith("samples/")
+        or ".." in Path(path).parts
     ):
         return None
     return f"https://github.com/{repository}/tree/{sha}/{quote(path, safe='/')}"

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -131,8 +131,16 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     run = value["run"]
     if not isinstance(run, dict):
         raise ContractError("run must be an object")
-    if set(run) != RUN_FIELDS:
-        raise ContractError(f"run is missing fields: {sorted(RUN_FIELDS - set(run))}")
+    run_fields = set(run)
+    missing_run_fields = RUN_FIELDS - run_fields
+    extra_run_fields = run_fields - RUN_FIELDS
+    if missing_run_fields or extra_run_fields:
+        problems = []
+        if missing_run_fields:
+            problems.append(f"missing fields: {sorted(missing_run_fields)}")
+        if extra_run_fields:
+            problems.append(f"extra fields: {sorted(extra_run_fields)}")
+        raise ContractError(f"run has {'; '.join(problems)}")
     timestamp(run["started_at"], "run.started_at")
     for field in ("diagnostic_reference", "artifact_reference"):
         reference = value[field]

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -43,6 +43,22 @@ class ContractError(ValueError):
     pass
 
 
+def _in(value: Any, container: Any) -> bool:
+    """Membership test that treats an unhashable value as simply absent.
+
+    Several checks below test membership of an untrusted JSON value (which
+    may be a list or dict) against a fixed set/dict of valid values. A bare
+    ``value in container`` raises ``TypeError`` for unhashable ``value``,
+    which would abort normalization instead of producing the
+    ``ContractError`` (and, in ``collect``, the infrastructure/error row)
+    callers expect for any malformed artifact.
+    """
+    try:
+        return value in container
+    except TypeError:
+        return False
+
+
 def load_json(path: Path, label: str) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -79,7 +95,7 @@ def load_expected(path: Path) -> list[dict[str, str]]:
     payload = load_json(path, "sample manifest")
     if (
         not isinstance(payload, dict)
-        or payload.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
+        or not _in(payload.get("schema_version"), SUPPORTED_SCHEMA_VERSIONS)
         or not isinstance(payload.get("samples"), list)
         or not payload["samples"]
     ):
@@ -96,7 +112,7 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     if (
         not isinstance(value, dict)
         or set(value) != REQUIRED
-        or value.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
+        or not _in(value.get("schema_version"), SUPPORTED_SCHEMA_VERSIONS)
     ):
         raise ContractError("result must be a supported schema object")
     missing = REQUIRED - value.keys()
@@ -105,7 +121,7 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     sample = sample_identity(value["sample"], "result sample")
     if sample != expected:
         raise ContractError(f"sample identity does not match manifest: {sample['id']}")
-    if value["outcome"] not in OUTCOMES:
+    if not _in(value["outcome"], OUTCOMES):
         raise ContractError(f"unsupported outcome: {value['outcome']!r}")
     if not isinstance(value["completed_stage"], str) or not value["completed_stage"]:
         raise ContractError("completed_stage must be non-empty")
@@ -113,8 +129,10 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
         raise ContractError("duration_seconds must be non-negative")
     timestamp(value["completed_at"], "completed_at")
     run = value["run"]
-    if not isinstance(run, dict) or set(run) != RUN_FIELDS:
-        raise ContractError(f"run is missing fields: {sorted(RUN_FIELDS - set(run or {}))}")
+    if not isinstance(run, dict):
+        raise ContractError("run must be an object")
+    if set(run) != RUN_FIELDS:
+        raise ContractError(f"run is missing fields: {sorted(RUN_FIELDS - set(run))}")
     timestamp(run["started_at"], "run.started_at")
     for field in ("diagnostic_reference", "artifact_reference"):
         reference = value[field]
@@ -140,6 +158,28 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     }
 
 
+def _load_run_fallback(results_dir: Path) -> dict[str, Any]:
+    """Best-effort run metadata for synthetic missing/invalid records.
+
+    The completeness job persists ``run-metadata.json`` alongside the
+    per-sample result directories in the same combined artifact. Synthetic
+    missing/invalid records have no per-sample ``run`` block of their own
+    (there's no successful result to draw one from); without this fallback
+    their Sample column can't link to the validated commit, and if every
+    sample is missing/invalid, callers relying on the first populated `run`
+    across all records get nothing at all and lose the run/commit context
+    entirely. Any read/parse problem here is non-fatal -- it just falls back
+    to an empty dict, matching the previous behavior.
+    """
+    try:
+        payload = json.loads((results_dir / "run-metadata.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {key: payload[key] for key in RUN_FIELDS if key in payload}
+
+
 def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dict[str, Any]], bool]:
     """Normalize every result artifact against the manifest.
 
@@ -154,23 +194,41 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
     expected_by_id = {value["id"]: value for value in expected}
     records: dict[str, dict[str, Any]] = {}
     incomplete = False
+    run_fallback = _load_run_fallback(results_dir)
     for path in sorted(results_dir.glob("*/sample-result.json")):
+        sample_id: Any = None
         try:
             raw = load_json(path, f"result artifact {path}")
-            sample_id = raw.get("sample", {}).get("id") if isinstance(raw, dict) else None
-            if sample_id not in expected_by_id:
-                raise ContractError(f"unexpected sample id: {sample_id}")
+            raw_sample = raw.get("sample") if isinstance(raw, dict) else None
+            sample_id = raw_sample.get("id") if isinstance(raw_sample, dict) else None
+            if not _in(sample_id, expected_by_id):
+                raise ContractError(f"unexpected sample id: {sample_id!r}")
             if sample_id in records:
                 raise ContractError(f"duplicate result artifact for {sample_id}")
             record = load_record(path, expected_by_id[sample_id])
             records[sample_id] = record
         except ContractError as exc:
             incomplete = True
-            records[f"invalid:{path}"] = {
-                "sample": {"id": path.name, "path": f"<invalid artifact: {path.name}>", "language": "reporting", "shape": "error"},
+            # Attribute the failure to the expected sample it claims to be,
+            # so long as that sample doesn't already have a record -- that
+            # keeps this one row per sample instead of also producing a
+            # separate "missing" row for the same sample below. An artifact
+            # that can't be attributed to any expected sample (or duplicates
+            # one already recorded) becomes its own extra, orphaned row.
+            if _in(sample_id, expected_by_id) and sample_id not in records:
+                key = sample_id
+                placeholder_sample = expected_by_id[sample_id]
+            else:
+                key = f"invalid:{path}"
+                placeholder_sample = {
+                    "id": path.name, "path": f"<invalid artifact: {path.name}>",
+                    "language": "reporting", "shape": "error",
+                }
+            records[key] = {
+                "sample": placeholder_sample,
                 "outcome": "infrastructure/error", "completed_stage": "reporting",
                 "duration_seconds": 0, "completed_at": None,
-                "diagnostic_reference": "—", "artifact_reference": path.name, "run": {},
+                "diagnostic_reference": "—", "artifact_reference": path.name, "run": dict(run_fallback),
                 "error": str(exc),
             }
     for sample in expected:
@@ -180,7 +238,7 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
                 "sample": sample, "outcome": "infrastructure/error",
                 "completed_stage": "reporting", "duration_seconds": 0,
                 "completed_at": None, "diagnostic_reference": "—",
-                "artifact_reference": "—", "run": {},
+                "artifact_reference": "—", "run": dict(run_fallback),
                 "error": f"expected result artifact is missing for {sample['id']}",
             }
     return sorted(records.values(), key=lambda value: value["sample"]["path"]), not incomplete

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -66,6 +66,10 @@ def _in(value: Any, container: Any) -> bool:
         return False
 
 
+def _is_supported_schema_version(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value in SUPPORTED_SCHEMA_VERSIONS
+
+
 def load_json(path: Path, label: str) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -104,7 +108,7 @@ def load_expected(path: Path) -> ExpectedSamples:
     payload = load_json(path, "sample manifest")
     if (
         not isinstance(payload, dict)
-        or not _in(payload.get("schema_version"), SUPPORTED_SCHEMA_VERSIONS)
+        or not _is_supported_schema_version(payload.get("schema_version"))
         or not isinstance(payload.get("samples"), list)
         or not payload["samples"]
     ):
@@ -121,7 +125,7 @@ def load_record(path: Path, expected: dict[str, str], expected_schema_version: i
     if (
         not isinstance(value, dict)
         or set(value) != REQUIRED
-        or not _in(value.get("schema_version"), SUPPORTED_SCHEMA_VERSIONS)
+        or not _is_supported_schema_version(value.get("schema_version"))
     ):
         raise ContractError("result must be a supported schema object")
     missing = REQUIRED - value.keys()

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -227,9 +227,11 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
                 key = sample_id
                 placeholder_sample = expected_by_id[sample_id]
             else:
-                key = f"invalid:{path}"
+                artifact_path = path.relative_to(results_dir).as_posix()
+                key = f"invalid:{artifact_path}"
                 placeholder_sample = {
-                    "id": path.name, "path": f"<invalid artifact: {path.name}>",
+                    "id": key,
+                    "path": f"<invalid artifact: {artifact_path}>",
                     "language": "reporting", "shape": "error",
                 }
             records[key] = {

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -163,6 +163,9 @@ def load_record(path: Path, expected: dict[str, str], expected_schema_version: i
         if extra_run_fields:
             problems.append(f"extra fields: {sorted(extra_run_fields)}")
         raise ContractError(f"run has {'; '.join(problems)}")
+    for field in RUN_FIELDS:
+        if not isinstance(run[field], str) or not run[field]:
+            raise ContractError(f"run.{field} must be a non-empty string")
     timestamp(run["started_at"], "run.started_at")
     for field in ("diagnostic_reference", "artifact_reference"):
         reference = value[field]
@@ -203,7 +206,7 @@ def _load_run_fallback(results_dir: Path) -> dict[str, Any]:
     """
     try:
         payload = json.loads((results_dir / "run-metadata.json").read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return {}
     if not isinstance(payload, dict):
         return {}

--- a/.github/scripts/validation_pilot_common.py
+++ b/.github/scripts/validation_pilot_common.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Shared contract/normalization logic for validation-pilot result consumers.
+
+This module owns only the data layer that every consumer of validation-pilot
+result artifacts (the Markdown report, the static dashboard, ...) must agree
+on: manifest/result schema validation, sample identity checks, timestamp
+parsing, and safe construction of a link to a sample at its validated commit.
+Presentation (Markdown vs. HTML, escaping, layout) stays in each renderer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+OUTCOMES = {
+    "passed": "✅ Passed",
+    "sample failure": "❌ Sample failure",
+    "infrastructure/error": "⚠️ Infrastructure/error",
+    "skipped/not-completed": "⏭️ Skipped/not-completed",
+}
+REQUIRED = {
+    "schema_version", "sample", "outcome", "completed_stage", "duration_seconds",
+    "diagnostic_reference", "artifact_reference", "completed_at", "run",
+}
+RUN_FIELDS = {"repository", "workflow", "run_id", "run_attempt", "sha", "ref", "started_at"}
+SUPPORTED_SCHEMA_VERSIONS = {1, 2}
+LEGACY_COMPLETED_STAGES = {
+    "L3 validation": "build readiness validation",
+    "L3 validation invocation": "build readiness invocation",
+    "L4 validation": "live-service validation",
+    "L4 validation invocation": "live-service validation invocation",
+}
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class ContractError(ValueError):
+    pass
+
+
+def load_json(path: Path, label: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ContractError(f"{label} not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ContractError(f"{label} is not valid JSON: {exc}") from exc
+
+
+def timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ContractError(f"{field} must be an ISO-8601 UTC timestamp ending in Z")
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ContractError(f"{field} is not a valid timestamp") from exc
+    if parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise ContractError(f"{field} must be UTC")
+    return parsed
+
+
+def sample_identity(value: Any, field: str) -> dict[str, str]:
+    keys = {"id", "path", "language", "shape"}
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ContractError(f"{field} must contain exactly id, path, language, and shape")
+    if any(not isinstance(value[key], str) or not value[key] for key in keys):
+        raise ContractError(f"{field} fields must be non-empty strings")
+    if not value["path"].startswith("samples/") or ".." in Path(value["path"]).parts:
+        raise ContractError(f"{field}.path must be a safe repository-relative samples/ path")
+    return {key: value[key] for key in keys}
+
+
+def load_expected(path: Path) -> list[dict[str, str]]:
+    payload = load_json(path, "sample manifest")
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
+        or not isinstance(payload.get("samples"), list)
+        or not payload["samples"]
+    ):
+        raise ContractError("sample manifest must contain a non-empty samples array")
+    samples = [sample_identity(value, "manifest sample") for value in payload["samples"]]
+    ids = [value["id"] for value in samples]
+    if ids != sorted(set(ids)):
+        raise ContractError("manifest samples must be sorted and unique by id")
+    return samples
+
+
+def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
+    value = load_json(path, f"result artifact {path}")
+    if (
+        not isinstance(value, dict)
+        or set(value) != REQUIRED
+        or value.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
+    ):
+        raise ContractError("result must be a supported schema object")
+    missing = REQUIRED - value.keys()
+    if missing:
+        raise ContractError(f"result is missing fields: {sorted(missing)}")
+    sample = sample_identity(value["sample"], "result sample")
+    if sample != expected:
+        raise ContractError(f"sample identity does not match manifest: {sample['id']}")
+    if value["outcome"] not in OUTCOMES:
+        raise ContractError(f"unsupported outcome: {value['outcome']!r}")
+    if not isinstance(value["completed_stage"], str) or not value["completed_stage"]:
+        raise ContractError("completed_stage must be non-empty")
+    if not isinstance(value["duration_seconds"], (int, float)) or isinstance(value["duration_seconds"], bool) or value["duration_seconds"] < 0:
+        raise ContractError("duration_seconds must be non-negative")
+    timestamp(value["completed_at"], "completed_at")
+    run = value["run"]
+    if not isinstance(run, dict) or set(run) != RUN_FIELDS:
+        raise ContractError(f"run is missing fields: {sorted(RUN_FIELDS - set(run or {}))}")
+    timestamp(run["started_at"], "run.started_at")
+    for field in ("diagnostic_reference", "artifact_reference"):
+        reference = value[field]
+        if (
+            not isinstance(reference, str)
+            or not reference
+            or Path(reference).is_absolute()
+            or ".." in Path(reference).parts
+            or len(Path(reference).parts) != 1
+        ):
+            raise ContractError(f"{field} must be a relative filename")
+    diagnostic = path.parent / value["diagnostic_reference"]
+    if not diagnostic.is_file():
+        raise ContractError(f"missing diagnostic: {diagnostic}")
+    completed_stage = LEGACY_COMPLETED_STAGES.get(
+        value["completed_stage"], value["completed_stage"]
+    )
+    return {
+        **value,
+        "completed_stage": completed_stage,
+        "completed_at": timestamp(value["completed_at"], "completed_at"),
+        "diagnostic_path": diagnostic,
+    }
+
+
+def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dict[str, Any]], bool]:
+    """Normalize every result artifact against the manifest.
+
+    Returns (records sorted by sample path, complete). ``complete`` is False
+    when any expected sample has no valid result, or an artifact is malformed.
+    Missing/invalid entries are represented as `infrastructure/error` records
+    carrying an `error` string, so callers can render a full picture without
+    re-implementing the completeness contract.
+    """
+    if not results_dir.is_dir():
+        raise ContractError(f"result artifact directory not found: {results_dir}")
+    expected_by_id = {value["id"]: value for value in expected}
+    records: dict[str, dict[str, Any]] = {}
+    incomplete = False
+    for path in sorted(results_dir.glob("*/sample-result.json")):
+        try:
+            raw = load_json(path, f"result artifact {path}")
+            sample_id = raw.get("sample", {}).get("id") if isinstance(raw, dict) else None
+            if sample_id not in expected_by_id:
+                raise ContractError(f"unexpected sample id: {sample_id}")
+            if sample_id in records:
+                raise ContractError(f"duplicate result artifact for {sample_id}")
+            record = load_record(path, expected_by_id[sample_id])
+            records[sample_id] = record
+        except ContractError as exc:
+            incomplete = True
+            records[f"invalid:{path}"] = {
+                "sample": {"id": path.name, "path": f"<invalid artifact: {path.name}>", "language": "reporting", "shape": "error"},
+                "outcome": "infrastructure/error", "completed_stage": "reporting",
+                "duration_seconds": 0, "completed_at": None,
+                "diagnostic_reference": "—", "artifact_reference": path.name, "run": {},
+                "error": str(exc),
+            }
+    for sample in expected:
+        if sample["id"] not in records:
+            incomplete = True
+            records[f"missing:{sample['id']}"] = {
+                "sample": sample, "outcome": "infrastructure/error",
+                "completed_stage": "reporting", "duration_seconds": 0,
+                "completed_at": None, "diagnostic_reference": "—",
+                "artifact_reference": "—", "run": {},
+                "error": f"expected result artifact is missing for {sample['id']}",
+            }
+    return sorted(records.values(), key=lambda value: value["sample"]["path"]), not incomplete
+
+
+def sample_url(record: dict[str, Any]) -> str | None:
+    run = record.get("run", {})
+    repository = run.get("repository")
+    sha = run.get("sha")
+    path = record["sample"]["path"]
+    if (
+        not isinstance(repository, str)
+        or not REPOSITORY_PATTERN.fullmatch(repository)
+        or not isinstance(sha, str)
+        or not SHA_PATTERN.fullmatch(sha)
+    ):
+        return None
+    return f"https://github.com/{repository}/tree/{sha}/{quote(path, safe='/')}"

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -95,7 +95,10 @@ whatever discovery's manifest already contains, so a sample with a
 inline diagnostic text — instead it links each sample's status to its job
 run for logs, and links to that sample's diagnostics artifact for download
 when one was uploaded, alongside stage, duration, completion time, and
-codeowner.
+codeowner. Failed and errored rows also provide a **Fix with Copilot** action.
+The action opens a prefilled issue for review with the sample, run, job, and
+artifact context and assigns it to Copilot when submitted; Copilot then
+investigates the failure and opens a pull request.
 
 ## Current limits
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -91,9 +91,11 @@ scheduled deployment, and republishes (with a visible banner) even when a run
 is incomplete rather than leaving a stale prior deployment looking current.
 New samples require no dashboard changes: like the report, it renders
 whatever discovery's manifest already contains, so a sample with a
-`sample.yaml` appears the next time the cadence runs. The dashboard omits
-diagnostic text entirely — it only shows outcome, stage, duration, and
-completion time, with a link to the workflow run for investigation.
+`sample.yaml` appears the next time the cadence runs. The dashboard doesn't
+inline diagnostic text — instead it links each sample's status to its job
+run for logs, and links to that sample's diagnostics artifact for download
+when one was uploaded, alongside stage, duration, completion time, and
+codeowner.
 
 ## Current limits
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -80,6 +80,21 @@ Open the
 [workflow runs](https://github.com/microsoft-foundry/foundry-samples/actions/workflows/validation-pilot.yml)
 to inspect the latest report and artifacts.
 
+## Dashboard
+
+The `publish-dashboard` job renders every manifest sample's latest outcome to
+a durable static page on GitHub Pages, so "what's currently passing" has one
+stable URL instead of requiring you to open the latest scheduled run. It only
+publishes from scheduled/dispatched runs on this repository's `main` branch,
+uses its own `pages` concurrency group so a manual dispatch can't race a
+scheduled deployment, and republishes (with a visible banner) even when a run
+is incomplete rather than leaving a stale prior deployment looking current.
+New samples require no dashboard changes: like the report, it renders
+whatever discovery's manifest already contains, so a sample with a
+`sample.yaml` appears the next time the cadence runs. The dashboard omits
+diagnostic text entirely — it only shows outcome, stage, duration, and
+completion time, with a link to the workflow run for investigation.
+
 ## Current limits
 
 The delivered cadence is daily/manual and warm-project only. Cold provisioning,

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -103,7 +103,9 @@ investigates the failure and opens a pull request.
 The dashboard's **Validation** column uses short reader-facing labels: **Build
 check** for local/static validation, **Live run** for samples executed against
 the warm Azure AI Foundry project, and setup/reporting labels for infrastructure
-or handoff failures.
+or handoff failures. Its filter panel is collapsed by default with a one-line
+summary of the visible rows; expanding it exposes filters for status, language,
+validation type, and codeowner.
 
 ## Current limits
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -100,6 +100,11 @@ The action opens a prefilled issue for review with the sample, run, job, and
 artifact context and assigns it to Copilot when submitted; Copilot then
 investigates the failure and opens a pull request.
 
+The dashboard's **Validation** column uses short reader-facing labels: **Build
+check** for local/static validation, **Live run** for samples executed against
+the warm Azure AI Foundry project, and setup/reporting labels for infrastructure
+or handoff failures.
+
 ## Current limits
 
 The delivered cadence is daily/manual and warm-project only. Cold provisioning,

--- a/.github/workflows/scripts-selftest.yml
+++ b/.github/workflows/scripts-selftest.yml
@@ -119,6 +119,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run normalized-artifact dashboard tests
         run: python .github/scripts/test/test-render-validation-dashboard.py
+      - name: Run fallback-dashboard tests
+        run: python .github/scripts/test/test-render-fallback-dashboard.py
       - name: Run per-sample job-link mapping tests
         run: python .github/scripts/test/test-collect-job-links.py
       - name: Run per-sample artifact-link mapping tests

--- a/.github/workflows/scripts-selftest.yml
+++ b/.github/workflows/scripts-selftest.yml
@@ -111,6 +111,19 @@ jobs:
       - name: Run normalized-artifact reporting tests
         run: python .github/scripts/test/test-render-validation-report.py
 
+  # --- Dashboard consumer contract tests: same fixture contract as report-harness, plus HTML-escaping
+  # and public-diagnostic-omission assertions specific to a durably published page ------------------
+  dashboard-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run normalized-artifact dashboard tests
+        run: python .github/scripts/test/test-render-validation-dashboard.py
+      - name: Run per-sample job-link mapping tests
+        run: python .github/scripts/test/test-collect-job-links.py
+      - name: Run per-sample artifact-link mapping tests
+        run: python .github/scripts/test/test-collect-artifact-links.py
+
   validation-pilot-contract:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -252,11 +252,15 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download normalized run
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
         with:
           name: validation-pilot-run-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/pilot-artifacts
       - name: Collect per-sample job links
+        if: always() && steps.download.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -268,6 +272,7 @@ jobs:
             --jobs-file "$RUNNER_TEMP/jobs.ndjson" \
             --output "$RUNNER_TEMP/pilot-artifacts/job-links.json"
       - name: Collect per-sample artifact links
+        if: always() && steps.download.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -279,19 +284,34 @@ jobs:
             --artifacts-file "$RUNNER_TEMP/artifacts.ndjson" \
             --repository "$GITHUB_REPOSITORY" \
             --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --output "$RUNNER_TEMP/pilot-artifacts/artifact-links.json"
       - name: Render dashboard
+        # Always renders *something* deployable, even when the run artifact
+        # above couldn't be downloaded (e.g. discovery or completeness
+        # failed before uploading it). Without this fallback, this step --
+        # and therefore the deploy-pages step below -- would simply never
+        # run, leaving whatever was deployed by a previous run looking like
+        # the current status. A visible "couldn't retrieve results" page is
+        # always preferable to a silently stale one.
+        if: always()
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/site"
-          python .github/scripts/render-validation-dashboard.py \
-            --results-dir "$RUNNER_TEMP/pilot-artifacts" \
-            --expected-samples "$RUNNER_TEMP/pilot-artifacts/manifest.json" \
-            --output "$RUNNER_TEMP/site/index.html" \
-            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            --job-links "$RUNNER_TEMP/pilot-artifacts/job-links.json" \
-            --artifact-links "$RUNNER_TEMP/pilot-artifacts/artifact-links.json" \
-            --codeowners .github/CODEOWNERS
+          if [ "${{ steps.download.outcome }}" = "success" ]; then
+            python .github/scripts/render-validation-dashboard.py \
+              --results-dir "$RUNNER_TEMP/pilot-artifacts" \
+              --expected-samples "$RUNNER_TEMP/pilot-artifacts/manifest.json" \
+              --output "$RUNNER_TEMP/site/index.html" \
+              --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              --job-links "$RUNNER_TEMP/pilot-artifacts/job-links.json" \
+              --artifact-links "$RUNNER_TEMP/pilot-artifacts/artifact-links.json" \
+              --codeowners .github/CODEOWNERS
+          else
+            python .github/scripts/render-fallback-dashboard.py \
+              --output "$RUNNER_TEMP/site/index.html" \
+              --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          fi
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -20,7 +20,7 @@ jobs:
       build_readiness_matrix: ${{ steps.discovery.outputs.build_readiness_matrix }}
       live_service_matrix: ${{ steps.discovery.outputs.live_service_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -59,7 +59,7 @@ jobs:
       max-parallel: 32
       matrix: ${{ fromJSON(needs.discover.outputs.build_readiness_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v4
         if: matrix.validator_language == 'csharp'
         with:
@@ -128,7 +128,7 @@ jobs:
       max-parallel: 4
       matrix: ${{ fromJSON(needs.discover.outputs.live_service_matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v4
         if: matrix.validator_language == 'csharp'
         with:
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v4
         with:
           pattern: validation-pilot-*
@@ -251,7 +251,7 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download normalized run
         id: download
         continue-on-error: true

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -261,6 +261,7 @@ jobs:
           path: ${{ runner.temp }}/pilot-artifacts
       - name: Collect per-sample job links
         if: always() && steps.download.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -273,6 +274,7 @@ jobs:
             --output "$RUNNER_TEMP/pilot-artifacts/job-links.json"
       - name: Collect per-sample artifact links
         if: always() && steps.download.outcome == 'success'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -298,7 +300,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/site"
-          if [ "${{ steps.download.outcome }}" = "success" ]; then
+          if [ "${{ steps.download.outcome }}" = "success" ] && \
             python .github/scripts/render-validation-dashboard.py \
               --results-dir "$RUNNER_TEMP/pilot-artifacts" \
               --expected-samples "$RUNNER_TEMP/pilot-artifacts/manifest.json" \
@@ -306,7 +308,8 @@ jobs:
               --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
               --job-links "$RUNNER_TEMP/pilot-artifacts/job-links.json" \
               --artifact-links "$RUNNER_TEMP/pilot-artifacts/artifact-links.json" \
-              --codeowners .github/CODEOWNERS
+              --codeowners .github/CODEOWNERS; then
+            :
           else
             python .github/scripts/render-fallback-dashboard.py \
               --output "$RUNNER_TEMP/site/index.html" \

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -218,3 +218,83 @@ jobs:
     with:
       results-artifact: validation-pilot-run-${{ github.run_id }}-${{ github.run_attempt }}
       manifest-path: manifest.json
+
+  # Publishes a durable "current status of every sample" dashboard to GitHub
+  # Pages. Unlike `report` (a run-scoped summary that only lives on this run's
+  # job summary page), this is the one stable URL for "what is passing right
+  # now". It intentionally still publishes on an incomplete completeness
+  # result (with a visible banner) rather than skip -- see
+  # render-validation-dashboard.py -- so a broken run is never silently masked
+  # by the previous day's stale deployment.
+  #
+  # Scoped to the canonical repository's default branch so a fork enabling its
+  # own Pages site can't be confused with this workflow's publication, and
+  # given its own `pages` concurrency group (queued, not cancel-in-progress)
+  # so a manual dispatch can never race a scheduled run's deployment.
+  publish-dashboard:
+    needs: completeness
+    if: >-
+      always() && !cancelled() &&
+      github.repository == 'microsoft-foundry/foundry-samples' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      actions: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: validation-pilot-run-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pilot-artifacts
+      - name: Collect per-sample job links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" \
+            --paginate -q '.jobs[] | {name, html_url}' \
+            > "$RUNNER_TEMP/jobs.ndjson"
+          python .github/scripts/collect-job-links.py \
+            --jobs-file "$RUNNER_TEMP/jobs.ndjson" \
+            --output "$RUNNER_TEMP/pilot-artifacts/job-links.json"
+      - name: Collect per-sample artifact links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" \
+            --paginate -q '.artifacts[] | {name, id}' \
+            > "$RUNNER_TEMP/artifacts.ndjson"
+          python .github/scripts/collect-artifact-links.py \
+            --artifacts-file "$RUNNER_TEMP/artifacts.ndjson" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/pilot-artifacts/artifact-links.json"
+      - name: Render dashboard
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/site"
+          python .github/scripts/render-validation-dashboard.py \
+            --results-dir "$RUNNER_TEMP/pilot-artifacts" \
+            --expected-samples "$RUNNER_TEMP/pilot-artifacts/manifest.json" \
+            --output "$RUNNER_TEMP/site/index.html" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --job-links "$RUNNER_TEMP/pilot-artifacts/job-links.json" \
+            --artifact-links "$RUNNER_TEMP/pilot-artifacts/artifact-links.json" \
+            --codeowners .github/CODEOWNERS
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ runner.temp }}/site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ commands and language behavior.
 
 The [daily public validation cadence](.github/validation-pilot.README.md)
 discovers metadata-bearing samples and publishes a run summary plus diagnostic
-artifacts in GitHub Actions.
+artifacts in GitHub Actions, plus a durable
+[validation dashboard](https://microsoft-foundry.github.io/foundry-samples/)
+showing every sample's latest status.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds a GitHub Pages dashboard that shows the status of every sample validated by the daily [`validation-pilot.yml`](.github/workflows/validation-pilot.yml) workflow. New samples with the required metadata are picked up automatically — no dashboard changes needed when the sample set grows.

Single sortable table, one row per sample:
- **Sample** — links to the file in the validated commit
- **Language**
- **Status** — badge, linked to that sample's job run for logs
- **Stage**, **Duration**, **Last checked**
- **Artifact** — download link (with icon) to that sample's diagnostics artifact, when one exists
- **Codeowner** — from `.github/CODEOWNERS`; combines the directory-level owner with any file-level owners nested inside the sample (e.g. `@AI-Platform-Docs` now shows up wherever it owns a file inside a sample, alongside the sample's primary owner)

Three all/toggle filter rows (outcome, language, codeowner) let you narrow the table; multiple filter rows combine with AND logic.

## How it stays current

The `publish-dashboard` job runs after every `validation-pilot` run (daily at 07:00 UTC, or manual dispatch) and only when on `main`. It re-renders the dashboard from that run's results and redeploys it to the same GitHub Pages site, so **the published page always reflects the most recent completed run** — it's replaced, not appended to.

## ⚠️ Action needed before this is live

**GitHub Pages must be enabled for this repo**: **Settings → Pages → Source: GitHub Actions**. Until that's done, the `publish-dashboard` job's deploy step will fail even though the rest of the workflow succeeds.

## Testing

Added/updated unit tests for the new scripts and the dashboard renderer (30 tests total across `test-render-validation-report.py`, `test-collect-job-links.py`, `test-collect-artifact-links.py`, `test-render-validation-dashboard.py`) — all passing. Also validated the rendered output against a real workflow run (76 samples) and iterated on layout/UX in a live preview.