### PR TITLE
Add model router session affinity sample

### DIFF
--- a/samples/python/foundry-models/model-router/README.md
+++ b/samples/python/foundry-models/model-router/README.md
@@ -10,6 +10,7 @@ Model Router is a deployable AI chat model in Azure AI Foundry that **automatica
 | ------ | --- | ---- | ----------- |
 | [`chat-completions/`](./model-router-chat-completions.py) | Chat Completions | API Key | Basic single-prompt chat completion via `AzureOpenAI` client |
 | [`model-router-chat-completions-observability.py`](./model-router-chat-completions-observability.py) | Chat Completions | API Key | Displays the selected model, routing mode, attempts, latency, and status for each routing decision |
+| [`model-router-chat-completions-session-affinity.py`](./model-router-chat-completions-session-affinity.py) | Chat Completions | API Key | Reuses a session ID across conversation turns to demonstrate session-aware model routing |
 | [`foundry-responses-sdk/`](./model-router-foundry-responses.py) | Foundry SDK | Entra ID | Uses `AIProjectClient` → `get_openai_client()` → Responses API |
 
 ## Prerequisites
@@ -45,7 +46,7 @@ Model Router is a deployable AI chat model in Azure AI Foundry that **automatica
 
    Edit `.env` with your values:
 
-   ```
+   ```text
    AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
    AZURE_OPENAI_API_KEY=your-api-key-here
    MODEL_DEPLOYMENT_NAME=model-router
@@ -107,6 +108,59 @@ The following JSON shows the `model_selection_details` fragment parsed by that c
 
 This payload is illustrative. The selected models, number of attempts, errors, latency, and preview response schema can vary by request and service version.
 
+### Chat Completions Session Affinity (Preview)
+
+```bash
+python model-router-chat-completions-session-affinity.py
+```
+
+This sample creates an opaque session ID and sends it in `routing_config.session_affinity.session_id` for two conversation turns. It parses the affinity mode, identity source, and final decision from a response fragment like this:
+
+```json
+{
+   "model_selection_details": {
+      "model_router_details": {
+         "mode": "balanced",
+         "session_affinity": {
+            "mode": "sticky",
+            "source": "session_id_payload",
+            "decision": "initialize"
+         }
+      }
+   }
+}
+```
+
+| Decision | Meaning |
+| -------- | ------- |
+| `initialize` | No previous model association was available, and the initially selected model served the response. |
+| `retain` | The associated model served the response. |
+| `switch` | Eligibility or fallback caused another model to serve the response. |
+
+The sample is designed to demonstrate `initialize` followed by `retain`, but fallback can produce `switch` on either turn. The sample reports the actual outcome instead of forcing a service failure. Use the Chat Completions observability sample to inspect the routing attempts behind a `switch` decision. Session affinity is best-effort and does not store conversation content or guarantee a provider cache hit.
+
+**Sample output:**
+```text
+--- First turn ---
+Serving model: grok-4-1-fast-reasoning
+Routing mode: balanced
+Affinity mode: sticky
+Affinity source: session_id_payload
+Affinity decision: initialize
+Response:
+### One-Day Family Trip Itinerary to Seattle
+
+--- Second turn ---
+Serving model: grok-4-1-fast-reasoning
+Routing mode: balanced
+Affinity mode: sticky
+Affinity source: session_id_payload
+Affinity decision: retain
+Response:
+### Updated One-Day Family Trip Itinerary to Seattle (with Restaurant Suggestions & Indoor Focus)
+
+```
+
 ### Foundry Responses SDK (Entra ID)
 
 ```bash
@@ -117,6 +171,7 @@ python model-router-foundry-responses.py
 ## What to Expect
 
 Each example prints:
+
 - **Which underlying model** was selected by the router (e.g. `gpt-4.1-mini-2025-04-14`)
 - **The model's response** to the prompt
 - Token usage

--- a/samples/python/foundry-models/model-router/model-router-chat-completions-session-affinity.py
+++ b/samples/python/foundry-models/model-router/model-router-chat-completions-session-affinity.py
@@ -54,13 +54,12 @@ messages = [
     {"role": "user", "content": "Plan a one-day family trip to Seattle."},
 ]
 
-# <session_affinity_invoke>
+# <session_affinity_turns>
 first_response = client.chat.completions.create(
     model=deployment,
     messages=messages,
     extra_body=session_affinity,
 )
-# </session_affinity_invoke>
 
 messages.extend(
     [
@@ -77,6 +76,7 @@ second_response = client.chat.completions.create(
     messages=messages,
     extra_body=session_affinity,
 )
+# </session_affinity_turns>
 
 def print_response(turn, response):
     print(f"\n--- {turn} ---")

--- a/samples/python/foundry-models/model-router/model-router-chat-completions-session-affinity.py
+++ b/samples/python/foundry-models/model-router/model-router-chat-completions-session-affinity.py
@@ -1,0 +1,104 @@
+"""
+Foundry Model Router - Chat Completions Session Affinity Example
+
+This example demonstrates how to use one session ID across separate
+Chat Completions requests so Model Router can keep using the associated
+eligible model while preserving normal fallback behavior.
+
+Prerequisites:
+  - An Azure OpenAI resource with a "model-router" deployment
+  - A .env file beside this script with AZURE_OPENAI_ENDPOINT,
+    AZURE_OPENAI_API_KEY, and MODEL_DEPLOYMENT_NAME
+
+Usage:
+    pip install -r requirements.txt
+    python model-router-chat-completions-session-affinity.py
+"""
+
+import os
+import uuid
+from pathlib import Path
+
+from dotenv import load_dotenv
+from openai import AzureOpenAI
+
+load_dotenv(Path(__file__).resolve().parent / ".env", override=True)
+
+endpoint = os.environ["AZURE_OPENAI_ENDPOINT"]
+api_key = os.environ["AZURE_OPENAI_API_KEY"]
+deployment = os.environ["MODEL_DEPLOYMENT_NAME"]
+
+# <session_affinity_enable>
+client = AzureOpenAI(
+    azure_endpoint=endpoint,
+    api_key=api_key,
+    api_version="2024-10-21",
+    default_headers={"Foundry-Features": "ModelRouterControls=V1Preview"},
+)
+
+# Use an opaque application-owned ID without secrets or personal information.
+# A fresh value makes the first request in each run establish a new association.
+session_id = f"trip-planner-{uuid.uuid4()}"
+session_affinity = {
+    "routing_config": {
+        "session_affinity": {
+            "mode": "sticky",
+            "session_id": session_id,
+        }
+    }
+}
+# </session_affinity_enable>
+
+messages = [
+    {"role": "system", "content": "You are a helpful travel planner."},
+    {"role": "user", "content": "Plan a one-day family trip to Seattle."},
+]
+
+# <session_affinity_invoke>
+first_response = client.chat.completions.create(
+    model=deployment,
+    messages=messages,
+    extra_body=session_affinity,
+)
+# </session_affinity_invoke>
+
+messages.extend(
+    [
+        {"role": "assistant", "content": first_response.choices[0].message.content},
+        {
+            "role": "user",
+            "content": "Add restaurant suggestions and indoor activities.",
+        },
+    ]
+)
+
+second_response = client.chat.completions.create(
+    model=deployment,
+    messages=messages,
+    extra_body=session_affinity,
+)
+
+def print_response(turn, response):
+    print(f"\n--- {turn} ---")
+    print(f"Serving model: {response.model}")
+
+    model_selection_details = getattr(response, "model_selection_details", None)
+    if not model_selection_details:
+        print("No model selection details were returned.")
+    else:
+        model_router_details = model_selection_details.get("model_router_details", {})
+
+        # <session_affinity_extract>
+        affinity_details = model_router_details.get("session_affinity")
+        if not affinity_details:
+            print("No session affinity details were returned.")
+        else:
+            print(f"Affinity mode: {affinity_details.get('mode', 'unknown')}")
+            print(f"Affinity source: {affinity_details.get('source', 'unknown')}")
+            print(f"Affinity decision: {affinity_details.get('decision', 'not reported')}")
+        # </session_affinity_extract>
+
+    print(f"Response:\n{response.choices[0].message.content}")
+
+print_response("First turn", first_response)
+print_response("Second turn", second_response)


### PR DESCRIPTION
## Summary

- add a Chat Completions sample that reuses an opaque session ID across conversation turns
- demonstrate the `ModelRouterControls=V1Preview` request contract and parse session-affinity mode, source, and decision metadata
- document expected `initialize`, `retain`, and `switch` outcomes with a representative balanced-routing response

## Validation

- compiled all Python samples in the model-router folder
- ran Ruff against the new sample
- ran `git diff --check main...HEAD`
- exercised the sample against a live deployment and observed `initialize` followed by `retain` on the same serving model