### PR TITLE
Add SchemaRAFT DST sample: deployment-faithful schema evaluation and finetuning recipe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 /samples/python/foundry-local/     @microsoft-foundry/foundry-local
 /samples/rust/foundry-local/       @microsoft-foundry/foundry-local
 
+# Fine-tuning samples — individually owned by their authors until a team slug exists.
+/samples/python/finetuning/schemaraft-dst/ @mikeslinmsft
+
 #### Partner / external collaborator sample areas #######################################################
 # Partners are outside collaborators (not org members). Each entry is the source of truth for that
 # partner. Update alongside step 3 of the onboarding process in docs/external-contributions.md.

--- a/samples/python/finetuning/schemaraft-dst/.env.example
+++ b/samples/python/finetuning/schemaraft-dst/.env.example
@@ -1,0 +1,9 @@
+# Microsoft Foundry resource endpoint. Keyless - no API key goes here.
+# Foundry portal -> your project -> Home. Do not append /openai/v1.
+AOAI_ENDPOINT=https://YOUR-RESOURCE.services.ai.azure.com
+
+# The deployment name to evaluate (your base model deployment to start with).
+DEPLOYMENT=gpt-4.1-mini
+
+# Base model to fine-tune, including the version suffix Azure requires.
+BASE_MODEL=gpt-4.1-mini-2025-04-14

--- a/samples/python/finetuning/schemaraft-dst/.gitignore
+++ b/samples/python/finetuning/schemaraft-dst/.gitignore
@@ -1,0 +1,7 @@
+data/
+results/
+.env
+finetune_job.json
+__pycache__/
+*.pyc
+.ruff_cache/

--- a/samples/python/finetuning/schemaraft-dst/README.md
+++ b/samples/python/finetuning/schemaraft-dst/README.md
@@ -12,7 +12,7 @@ distractors.
 
 The collapse is **not** a retrieval miss. On the subset of turns where the gold
 schema demonstrably *was* in the prompt, the base model still only reaches
-**24.8 JGA**. Better retrieval cannot fix that number.
+**24.0 JGA**. Better retrieval cannot fix that number.
 
 The sample then ships **SchemaRAFT**, the fine-tuning recipe that closes most of
 the gap (18.3 → 45.0) by building every training prompt the way the serving
@@ -37,7 +37,7 @@ Everything runs on the public [Schema-Guided Dialogue][sgd] dataset (CC BY-SA 4.
 | `goldpresent_strata.py` | Splits results by whether the gold schema was in the prompt. **This is the step that carries the argument.** |
 | `build_sft_data.py` | Emits the SchemaRAFT training file. |
 | `submit_finetune.py` | Submits and monitors the fine-tuning job. |
-| `selftest.py` | 40 offline checks over bundled fixtures. No Azure calls, no tokens. |
+| `selftest.py` | 42 offline checks over bundled fixtures. No Azure calls, no tokens. |
 
 The four modes in `build_prompts.py` are the whole experiment:
 
@@ -271,7 +271,10 @@ SGD test, n=1,810 turns, `gpt-4.1-mini` unless noted.
 | Retrieved top-3, base | 55.6 |
 | Oracle gold schema, base | 58.0 |
 
-Gold-in-prompt stratum: base **24.8** → SchemaRAFT **64.4**.
+Gold-in-prompt stratum: base **24.0** → SchemaRAFT **62.7**. This stratum is
+every turn where the gold schema reached the prompt — whether BM25 ranked it
+top-1 or a distractor draw happened to surface it — which is exactly what
+`goldpresent_strata.py` reports.
 
 Prompting does not substitute for this. A frontier reasoning model, prompted,
 reaches 16.6 JGA on the same turns at roughly 4.4 s and 24x the per-turn cost;

--- a/samples/python/finetuning/schemaraft-dst/README.md
+++ b/samples/python/finetuning/schemaraft-dst/README.md
@@ -1,0 +1,300 @@
+# SchemaRAFT — Deployment-Faithful Schema Evaluation for Dialogue State Tracking
+
+Schema-guided dialogue state tracking (DST) is almost always evaluated with the
+**correct service schema already in the prompt**. A deployed assistant does not
+get that. It retrieves candidate schemas from a registry, and the prompt ends up
+holding the right schema *plus* whatever else the retriever dragged in.
+
+This sample changes exactly one thing — how schemas reach the prompt — and
+measures what that costs. On SGD, the same `gpt-4.1-mini` deployment scores
+**58.0 JGA** with the gold schema and **18.3 JGA** under retrieval with
+distractors.
+
+The collapse is **not** a retrieval miss. On the subset of turns where the gold
+schema demonstrably *was* in the prompt, the base model still only reaches
+**24.8 JGA**. Better retrieval cannot fix that number.
+
+The sample then ships **SchemaRAFT**, the fine-tuning recipe that closes most of
+the gap (18.3 → 45.0) by building every training prompt the way the serving
+prompt gets built.
+
+Everything runs on the public [Schema-Guided Dialogue][sgd] dataset (CC BY-SA 4.0).
+
+[sgd]: https://github.com/google-research-datasets/dstc8-schema-guided-dialogue
+
+---
+
+## What's in here
+
+| Path | What it does |
+|---|---|
+| `download_sgd.py` | Fetches SGD. Retrieval at test time runs over the 21-service test registry; SGD defines 45 services / 20 domains overall. |
+| `sgd_data.py` | Loads dialogues into DST turns and serialises schemas. Single source of truth for both eval and training. |
+| `schema_retriever.py` | BM25 over the registry, plus distractor sampling. Pure standard library. |
+| `build_prompts.py` | The four schema-delivery modes, the response parser, and the metrics. |
+| `foundry_client.py` | Keyless Microsoft Foundry client via `DefaultAzureCredential`. |
+| `eval_jga.py` | Runs an evaluation and reports Joint Goal Accuracy. `--mode` is the experiment. |
+| `goldpresent_strata.py` | Splits results by whether the gold schema was in the prompt. **This is the step that carries the argument.** |
+| `build_sft_data.py` | Emits the SchemaRAFT training file. |
+| `submit_finetune.py` | Submits and monitors the fine-tuning job. |
+| `selftest.py` | 40 offline checks over bundled fixtures. No Azure calls, no tokens. |
+
+The four modes in `build_prompts.py` are the whole experiment:
+
+| `--mode` | What the model sees | What it measures |
+|---|---|---|
+| `none` | no schema | how much the model is running on memorised slot names |
+| `oracle` | the one correct schema | the number papers report |
+| `retrieved` | BM25 top-*k* | retrieval quality alone |
+| `retrieved_distractor` | BM25 top-1 + *n* random schemas | **what your users get** |
+
+---
+
+## Prerequisites
+
+### 1. Access to Microsoft Foundry
+
+You need an Azure subscription and a **Microsoft Foundry** resource with a chat
+model deployment. If you have never used Foundry:
+
+1. Sign in at [ai.azure.com](https://ai.azure.com) with an Azure account and
+   make sure the **New Foundry** toggle is on. A
+   [free account](https://azure.microsoft.com/free/) is enough for steps 1-4.
+2. Create a project. The portal creates the underlying Foundry resource for you.
+   Walkthrough: [Create a project][doc-project].
+3. Deploy a small chat model - `gpt-4.1-mini` is what the numbers below use.
+   Walkthrough: [Deploy a model][doc-deploy]. Note the **deployment name**; that
+   is what `--deployment` wants, not the model name.
+4. Copy the endpoint into `AOAI_ENDPOINT`. In the portal it sits on the project
+   **Home** page next to the API key; ignore the key, this sample uses Microsoft
+   Entra ID. Either `https://<resource>.services.ai.azure.com` or
+   `https://<resource>.openai.azure.com` works - the code appends `/openai/v1`.
+5. Model availability is regional, and each deployment draws on a
+   tokens-per-minute quota. Check [models and regions][doc-region] and
+   [quotas and limits][doc-quota] before you pick one.
+6. Fine-tuning (step 5 only) runs on a subset of models and regions, and only on
+   a resource's **default project** - see [fine-tuning][doc-ft]. Steps 1-4 need
+   no fine-tuning.
+
+[doc-project]: https://learn.microsoft.com/azure/foundry/how-to/create-projects
+[doc-deploy]: https://learn.microsoft.com/azure/foundry/foundry-models/how-to/deploy-foundry-models
+[doc-region]: https://learn.microsoft.com/azure/foundry/concepts/models-sold-directly-by-azure
+[doc-quota]: https://learn.microsoft.com/azure/foundry/foundry-models/quotas-limits
+[doc-ft]: https://learn.microsoft.com/azure/ai-foundry/openai/how-to/fine-tuning
+
+### 2. Permissions
+
+This sample is **keyless**. It authenticates with `DefaultAzureCredential`, so
+no API key is ever written to disk. That means your identity needs a role, not a
+secret.
+
+| To do this | Role on the Foundry resource | Role definition ID |
+|---|---|---|
+| Steps 2-4 (inference only) | **Foundry User** | `53ca6127-db72-4b80-b1b0-d745d6d5456d` |
+| Step 5 (fine-tune and deploy) | **Foundry Owner** | `c883944f-8b7b-4483-af10-35834be79c4a` |
+
+Fine-tuning needs both data-plane and control-plane permissions, and **Foundry
+Owner** is the only built-in role that carries both. If you would rather not
+grant it, **Foundry User** plus **Foundry Account Owner**
+(`e47c6f54-e4a2-4754-9501-8e0985b135e1`) is the equivalent pair.
+
+Two things that trip people up:
+
+- **Do not use the `Cognitive Services *` roles**, or `Azure AI Developer`, for
+  this. They target AI Services resources directly and do not apply to Foundry
+  projects. See [role-based access control for Microsoft Foundry][doc-rbac].
+- Being subscription **Owner** does not imply data-plane access. The role has to
+  be assigned explicitly at the Foundry resource or project scope.
+
+These roles were renamed recently (**Foundry User** was *Azure AI User*, and so
+on). Pass the **role definition ID** rather than the display name while the
+rename rolls out:
+
+```bash
+az role assignment create \
+  --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
+  --assignee "<your-user-principal-name>" \
+  --assignee-principal-type User \
+  --scope "/subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<foundry-resource>"
+```
+
+If your organisation blocks keyless access, that is a policy question for your
+admin — this sample has no API-key fallback by design.
+
+[doc-rbac]: https://learn.microsoft.com/azure/foundry/concepts/rbac-foundry
+
+### 3. Local setup
+
+```bash
+python -m pip install -r requirements.txt
+cp .env.example .env          # set AOAI_ENDPOINT and DEPLOYMENT
+az login                      # DefaultAzureCredential picks this up
+```
+
+Requires Python 3.10+ and the [Azure CLI][doc-cli]. The only dependencies are
+`openai` and `azure-identity` — BM25, the SGD download, and the metrics are all
+standard library.
+
+If you belong to more than one tenant, add `--tenant <tenant-id>` to `az login`.
+Otherwise `DefaultAzureCredential` uses whichever tenant the CLI defaulted to,
+and you get a 401 that looks like a role problem but is not.
+
+[doc-cli]: https://learn.microsoft.com/cli/azure/install-azure-cli
+
+### Troubleshooting
+
+| Symptom | Most likely cause |
+|---|---|
+| `401 Unauthorized` | `az login` session is on the wrong tenant, or a fresh role assignment has not propagated yet. |
+| `403 Forbidden` | Identity has no **Foundry User** role at the resource or project scope. Subscription Owner is not enough. |
+| `404 DeploymentNotFound` | `--deployment` was given the model name instead of the deployment name. |
+| `429` on most calls | The deployment's tokens-per-minute quota is too low. Lower `--concurrency` or raise the quota. |
+| Endpoint rejected at startup | `AOAI_ENDPOINT` must be an `https://` URL. Do not append `/openai/v1` yourself. |
+
+---
+
+## Runbook
+
+Steps 1–4 take roughly 20 minutes and cost only inference tokens on ~400 turns.
+Step 5 is optional and is the only part that costs real money.
+
+### Step 0 — Confirm the checkout works (offline, free)
+
+```bash
+python selftest.py
+```
+
+40 checks over bundled fixtures: retrieval ranking, all four prompt modes, seed
+determinism, the JSON parser, JGA scoring, the training-data builder, and the
+stratification maths. No network, no Azure. If this fails, the problem is your
+checkout, not your deployment.
+
+### Step 1 — Get the data
+
+```bash
+python download_sgd.py --splits test          # enough for steps 2-4
+python download_sgd.py --splits train test    # add this before step 5
+```
+
+### Step 2 — The number papers report
+
+The gold schema is placed directly in the prompt.
+
+```bash
+python eval_jga.py --mode oracle \
+    --deployment <your-deployment> --n 200 \
+    --output-dir results/oracle
+```
+
+### Step 3 — The number your users get
+
+One flag changes. `retrieved_distractor` retrieves BM25 top-1 and adds two
+random schemas from the registry, shuffled — the shape of a real serving prompt.
+
+```bash
+python eval_jga.py --mode retrieved_distractor \
+    --deployment <your-deployment> --n 200 \
+    --n-schemas 1 --n-distractors 2 \
+    --output-dir results/retdist
+```
+
+Compare `results/*/summary.json`. On `gpt-4.1-mini` this is roughly **58 vs 18**.
+
+Same turns, same order, same prompt template, same metric, same weights. Runs
+are reproducible from `--seed` alone.
+
+### Step 4 — Prove it is not a retrieval problem
+
+This is the step that matters.
+
+```bash
+python goldpresent_strata.py --results results/retdist
+```
+
+It splits the turns into those where the correct schema really was in the prompt
+and those where it was not, and reports JGA on each. Read it this way:
+
+- Low JGA where the gold schema was **absent** is expected and uninteresting.
+  The model was never shown the answer.
+- Low JGA where the gold schema was **present** is the finding. The correct
+  schema was sitting in the context and the model still got the turn wrong. No
+  amount of retrieval tuning fixes that.
+- The abstention rate on the gold-absent stratum tells you whether the model
+  degrades safely. Emitting `{}` is correct there; inventing slots from a
+  distractor schema is not.
+
+We call the gap between the oracle number and the gold-present number
+**schema-following collapse**.
+
+### Step 5 — The fix: train on the noise (optional, costs money)
+
+SchemaRAFT is [RAFT][raft] applied to retrieved *schemas* instead of retrieved
+*documents*. Build the training data so it looks like the deployment prompt:
+
+- 1 correct schema + 2 random distractors per example, shuffled, exactly as at
+  serving time
+- **20% of examples omit the correct schema entirely and are labelled `{}`.**
+  That fraction is what teaches the model to abstain instead of guessing. Set it
+  to zero and the model learns that some schema in the prompt is always right —
+  which is the habit that breaks in production.
+
+```bash
+python build_sft_data.py --split train \
+    --n-distractors 2 --gold-absent-frac 0.2 \
+    --out data/schemaraft_train.jsonl
+
+python submit_finetune.py --train-file data/schemaraft_train.jsonl --epochs 3
+```
+
+Deploy the resulting model in the Foundry portal, then re-run step 3 against the
+new deployment name and compare.
+
+> **Cost.** The full train split yields ~19,300 examples (~124M training tokens
+> over 3 epochs). Budget on the order of $150 plus several hours of queue time,
+> and check current [fine-tuning pricing][doc-price] first. Use
+> `--max-dialogues 2000` for a cheap smoke run. Steps 1–4 cost only inference.
+
+[raft]: https://arxiv.org/abs/2403.10131
+[doc-price]: https://azure.microsoft.com/pricing/details/cognitive-services/openai-service/
+
+---
+
+## Reported results
+
+SGD test, n=1,810 turns, `gpt-4.1-mini` unless noted.
+
+| Condition | JGA |
+|---|---:|
+| No schema in prompt | 2.0 |
+| Retrieval + distractors, base | 18.3 |
+| **Retrieval + distractors, SchemaRAFT** | **45.0** |
+| Retrieved top-3, base | 55.6 |
+| Oracle gold schema, base | 58.0 |
+
+Gold-in-prompt stratum: base **24.8** → SchemaRAFT **64.4**.
+
+Prompting does not substitute for this. A frontier reasoning model, prompted,
+reaches 16.6 JGA on the same turns at roughly 4.4 s and 24x the per-turn cost;
+the fine-tuned small model reaches 45.0 at roughly 1.1 s and 1.0x.
+
+Your absolute numbers will differ with model version, region, and sampling. The
+**gap between step 2 and step 3** is the reproducible part.
+
+---
+
+## When this will not reproduce
+
+The gap needs schemas that are genuinely **confusable**. SGD defines 45 services
+across 20 domains with heavily overlapping slot names — the slot `city` alone
+appears in 9 of them, and 15 services carry some `*city*` variant. If the schemas
+in your own registry are clearly distinguishable, a model that retrieves the
+wrong one tends to notice, and the collapse is much smaller.
+
+Run steps 2–4 against your own registry before deciding to fine-tune.
+
+---
+
+## License
+
+Code: MIT, per the repository root. The SGD dataset is downloaded at runtime
+from Google Research under CC BY-SA 4.0; it is not redistributed here.

--- a/samples/python/finetuning/schemaraft-dst/build_prompts.py
+++ b/samples/python/finetuning/schemaraft-dst/build_prompts.py
@@ -1,0 +1,132 @@
+"""Prompt construction, response parsing, and DST metrics.
+
+`MODES` is the whole point of this sample. Every mode shows the model the same
+dialogue and asks for the same JSON; the only thing that changes is how the
+schema reaches the prompt.
+"""
+from __future__ import annotations
+
+import json
+import random
+import re
+
+from schema_retriever import SchemaRetriever
+from sgd_data import schema_to_text
+
+MODES = ("none", "oracle", "retrieved", "retrieved_distractor")
+
+SYSTEM_TEMPLATE = """\
+You are a dialogue state tracker for task-oriented conversations.
+
+Your task: given a conversation history and the service schemas below, output \
+the CURRENT CUMULATIVE belief state as a JSON object mapping slot names to values.
+
+Rules:
+- Output ONLY a valid JSON object on a single line.
+- Use only slot names that appear in the schemas below.
+- Include ALL slots mentioned so far (cumulative, not just the last turn).
+- If no relevant slots have been mentioned, output: {{}}
+
+{schemas_block}"""
+
+SYSTEM_TEMPLATE_NO_SCHEMA = """\
+You are a dialogue state tracker for task-oriented conversations.
+
+Your task: given a conversation history, output the CURRENT CUMULATIVE belief \
+state as a JSON object mapping slot names to values.
+
+Rules:
+- Output ONLY a valid JSON object on a single line.
+- Include ALL slots mentioned so far (cumulative, not just the last turn).
+- If no relevant slots have been mentioned, output: {}"""
+
+USER_TEMPLATE = """\
+Conversation history:
+{history}
+
+Extract the current belief state for service: {service}"""
+
+SCHEMA_HEADER = "Service schemas (one is relevant; others may be distractors):\n"
+SCHEMA_SEP = "\n" + "-" * 50 + "\n"
+
+
+def build_schemas_block(schemas: list[dict]) -> str:
+    return SCHEMA_HEADER + SCHEMA_SEP.join(schema_to_text(s) for s in schemas)
+
+
+def select_schemas(
+    history: list[str],
+    service: str,
+    schema_map: dict[str, dict],
+    mode: str,
+    retriever: SchemaRetriever | None,
+    n_schemas: int,
+    n_distractors: int,
+    rng: random.Random,
+) -> list[dict]:
+    """Choose which schemas the model gets to see."""
+    if mode not in MODES:
+        raise ValueError(f"unknown mode {mode!r}; expected one of {MODES}")
+    if mode == "none":
+        return []
+    if mode == "oracle":
+        gold = schema_map.get(service)
+        return [gold] if gold else []
+
+    if retriever is None:
+        raise ValueError(f"mode={mode} requires a SchemaRetriever")
+    schemas = retriever.retrieve(history, k=max(1, n_schemas))
+    if mode == "retrieved_distractor" and n_distractors > 0:
+        exclude = {s["service_name"] for s in schemas}
+        schemas = schemas + retriever.sample_distractors(exclude, n_distractors, rng)
+        rng.shuffle(schemas)
+    return schemas
+
+
+def build_messages(
+    history: list[str],
+    service: str,
+    schemas: list[dict],
+) -> list[dict]:
+    system = (
+        SYSTEM_TEMPLATE_NO_SCHEMA
+        if not schemas
+        else SYSTEM_TEMPLATE.format(schemas_block=build_schemas_block(schemas))
+    )
+    user = USER_TEMPLATE.format(history="\n".join(history), service=service)
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+
+def parse_belief_json(raw: str) -> dict[str, str]:
+    """Extract the belief state, tolerating markdown fences and trailing prose."""
+    raw = re.sub(r"```(?:json)?\s*", "", raw.strip()).strip("`").strip()
+    for candidate in (raw, (re.search(r"\{[^{}]*\}", raw, re.DOTALL) or [None])[0]):
+        if not candidate:
+            continue
+        try:
+            obj = json.loads(
+                candidate if isinstance(candidate, str) else candidate.group()
+            )
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            continue
+        if isinstance(obj, dict):
+            return {k: str(v).strip().lower() for k, v in obj.items()}
+    return {}
+
+
+def exact_match(pred: dict[str, str], gold: dict[str, str]) -> bool:
+    """Joint goal accuracy for one turn: every slot exactly right, no extras."""
+    return pred == gold
+
+
+def slot_f1(pred: dict[str, str], gold: dict[str, str]) -> tuple[float, float, float]:
+    pred_set = {f"{k}={v}" for k, v in pred.items()}
+    gold_set = {f"{k}={v}" for k, v in gold.items()}
+    if not gold_set and not pred_set:
+        return 1.0, 1.0, 1.0
+    if not pred_set or not gold_set:
+        return 0.0, 0.0, 0.0
+    tp = len(pred_set & gold_set)
+    prec, rec = tp / len(pred_set), tp / len(gold_set)
+    f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+    return prec, rec, f1

--- a/samples/python/finetuning/schemaraft-dst/build_sft_data.py
+++ b/samples/python/finetuning/schemaraft-dst/build_sft_data.py
@@ -1,0 +1,90 @@
+"""Build the SchemaRAFT fine-tuning file.
+
+    python build_sft_data.py --split train --out data/schemaraft_train.jsonl
+
+The recipe is one idea: assemble every training prompt the way the serving
+prompt gets assembled. Concretely, each example carries the retrieved correct
+schema plus `--n-distractors` confusable ones, shuffled so position carries no
+signal.
+
+`--gold-absent-frac` of examples contain no correct schema at all and are
+labelled with an empty state. That fraction is what teaches abstention. Drop it
+to zero and the model learns that some schema in the prompt is always the right
+one, which is exactly the habit that breaks in production.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+from build_prompts import build_messages
+from schema_retriever import SchemaRetriever
+from sgd_data import DEFAULT_DATA_DIR, load_schema_map, load_turns, resolve_split
+
+
+def build(args) -> None:
+    split_dir = resolve_split(args.data_dir, args.split)
+    schema_map = load_schema_map(split_dir)
+    turns = load_turns(split_dir, max_dialogues=args.max_dialogues, seed=args.seed)
+    retriever = SchemaRetriever(schema_map)
+    rng = random.Random(args.seed)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    n_gold_absent = 0
+    with args.out.open("w", encoding="utf-8") as f:
+        for turn in turns:
+            gold = schema_map.get(turn["service"])
+            if gold is None:
+                continue
+
+            if rng.random() < args.gold_absent_frac:
+                # No correct schema anywhere in the prompt; the target is {}.
+                schemas = retriever.sample_distractors(
+                    {turn["service"]}, args.n_distractors + 1, rng
+                )
+                target: dict[str, str] = {}
+                n_gold_absent += 1
+            else:
+                schemas = [gold] + retriever.sample_distractors(
+                    {turn["service"]}, args.n_distractors, rng
+                )
+                target = turn["gold_belief"]
+
+            rng.shuffle(schemas)
+            messages = build_messages(turn["history"], turn["service"], schemas)
+            messages.append(
+                {"role": "assistant", "content": json.dumps(target, ensure_ascii=False)}
+            )
+            f.write(json.dumps({"messages": messages}, ensure_ascii=False) + "\n")
+
+    total = sum(1 for _ in args.out.open(encoding="utf-8"))
+    print(f"[out] {args.out}")
+    print(f"      {total:,} examples, {args.out.stat().st_size / 1e6:.1f} MB")
+    print(
+        f"      gold-absent: {n_gold_absent:,} ({n_gold_absent / max(total, 1) * 100:.1f}%)"
+    )
+    print(f"      schemas per prompt: {args.n_distractors + 1}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    ap.add_argument("--split", default="train", choices=["train", "dev", "test"])
+    ap.add_argument("--n-distractors", type=int, default=2)
+    ap.add_argument("--gold-absent-frac", type=float, default=0.2)
+    ap.add_argument("--max-dialogues", type=int, default=None)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=Path(__file__).resolve().parent / "data" / "schemaraft_train.jsonl",
+    )
+    build(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/finetuning/schemaraft-dst/download_sgd.py
+++ b/samples/python/finetuning/schemaraft-dst/download_sgd.py
@@ -1,0 +1,88 @@
+"""Fetch the Schema-Guided Dialogue (SGD) dataset.
+
+SGD is published by Google Research under CC BY-SA 4.0:
+https://github.com/google-research-datasets/dstc8-schema-guided-dialogue
+
+    python download_sgd.py                 # train + dev + test into ./data/sgd
+    python download_sgd.py --splits test   # just what steps 2-4 need
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import shutil
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ARCHIVE_URL = (
+    "https://github.com/google-research-datasets/"
+    "dstc8-schema-guided-dialogue/archive/refs/heads/master.zip"
+)
+ARCHIVE_ROOT = "dstc8-schema-guided-dialogue-master"
+DEFAULT_OUT = Path(__file__).resolve().parent / "data" / "sgd"
+
+
+def _wanted(member: str, splits: list[str]) -> str | None:
+    """Return the destination path relative to OUT, or None to skip."""
+    parts = Path(member).parts
+    # Expect: <ARCHIVE_ROOT>/<split>/<file.json>
+    if len(parts) != 3 or parts[0] != ARCHIVE_ROOT:
+        return None
+    split, name = parts[1], parts[2]
+    if split not in splits or not name.endswith(".json"):
+        return None
+    if name != "schema.json" and not name.startswith("dialogues_"):
+        return None
+    return f"{split}/{name}"
+
+
+def download(out_dir: Path, splits: list[str]) -> None:
+    print(f"[get] {ARCHIVE_URL}")
+    with urllib.request.urlopen(
+        ARCHIVE_URL, timeout=300
+    ) as resp:  # noqa: S310 - fixed https URL
+        blob = resp.read()
+    print(f"[get] {len(blob) / 1e6:.1f} MB")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        for info in zf.infolist():
+            rel = _wanted(info.filename, splits)
+            if rel is None:
+                continue
+            dest = out_dir / rel
+            # Guard against zip-slip: the resolved path must stay under out_dir.
+            if not dest.resolve().is_relative_to(out_dir.resolve()):
+                raise RuntimeError(f"refusing unsafe archive member: {info.filename}")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, dest.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+            written += 1
+    print(f"[ok] wrote {written} files to {out_dir}")
+
+    for split in splits:
+        d = out_dir / split
+        n_dlg = len(list(d.glob("dialogues_*.json")))
+        print(
+            f"     {split}: {n_dlg} dialogue files, schema.json "
+            f"{'present' if (d / 'schema.json').exists() else 'MISSING'}"
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument(
+        "--splits",
+        nargs="+",
+        default=["train", "dev", "test"],
+        choices=["train", "dev", "test"],
+    )
+    args = ap.parse_args()
+    download(args.out, args.splits)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/finetuning/schemaraft-dst/eval_jga.py
+++ b/samples/python/finetuning/schemaraft-dst/eval_jga.py
@@ -1,0 +1,196 @@
+"""Evaluate dialogue state tracking under a chosen schema-delivery mode.
+
+    python eval_jga.py --mode oracle               --n 200
+    python eval_jga.py --mode retrieved_distractor --n 200
+
+Everything except `--mode` is held fixed: same turns, same order, same prompt
+template, same metric. The per-turn JSONL this writes records which schemas were
+actually shown, which is what `goldpresent_strata.py` later needs to separate a
+retrieval failure from a schema-following failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from build_prompts import (
+    MODES,
+    build_messages,
+    exact_match,
+    parse_belief_json,
+    select_schemas,
+    slot_f1,
+)
+from foundry_client import make_client
+from schema_retriever import SchemaRetriever
+from sgd_data import DEFAULT_DATA_DIR, load_schema_map, load_turns, resolve_split
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_dotenv_if_present() -> None:
+    env = HERE / ".env"
+    if not env.exists():
+        return
+    for line in env.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip())
+
+
+def call_model(
+    client,
+    deployment: str,
+    messages: list[dict],
+    max_attempts: int = 3,
+    timeout: float = 60.0,
+) -> str:
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resp = client.chat.completions.create(
+                model=deployment,
+                messages=messages,
+                temperature=0.0,
+                max_tokens=256,
+                timeout=timeout,
+            )
+            return (resp.choices[0].message.content or "").strip()
+        except Exception as exc:
+            last_exc = exc
+            status = getattr(exc, "status_code", None)
+            if status is not None and 400 <= status < 500 and status != 429:
+                return ""  # content filter / bad request: score as an empty prediction
+            time.sleep(2**attempt)
+    print(f"  [warn] giving up on a turn: {last_exc}", file=sys.stderr)
+    return ""
+
+
+def evaluate(args) -> dict:
+    split_dir = resolve_split(args.data_dir, args.split)
+    schema_map = load_schema_map(split_dir)
+    turns = load_turns(split_dir, seed=args.seed)
+    if args.n and args.n < len(turns):
+        turns = random.Random(args.seed).sample(turns, args.n)
+
+    print(f"[data] {len(turns):,} turns | registry: {len(schema_map)} services")
+    print(
+        f"[mode] {args.mode}  n_schemas={args.n_schemas}  n_distractors={args.n_distractors}"
+    )
+
+    retriever = None
+    if args.mode in ("retrieved", "retrieved_distractor"):
+        retriever = SchemaRetriever(schema_map)
+
+    # One RNG, consumed in turn order, so a run is reproducible from --seed alone.
+    rng = random.Random(args.seed)
+    prepared = []
+    for turn in turns:
+        schemas = select_schemas(
+            turn["history"],
+            turn["service"],
+            schema_map,
+            args.mode,
+            retriever,
+            args.n_schemas,
+            args.n_distractors,
+            rng,
+        )
+        prepared.append(
+            (
+                turn,
+                [s["service_name"] for s in schemas],
+                build_messages(turn["history"], turn["service"], schemas),
+            )
+        )
+
+    client = make_client(args.endpoint)
+
+    def run_one(idx_item):
+        idx, (turn, shown, messages) = idx_item
+        raw = call_model(client, args.deployment, messages)
+        pred = parse_belief_json(raw)
+        return idx, turn, shown, pred
+
+    records: list[dict] = [None] * len(prepared)  # type: ignore[list-item]
+    done = 0
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        for idx, turn, shown, pred in pool.map(run_one, enumerate(prepared)):
+            prec, rec, f1 = slot_f1(pred, turn["gold_belief"])
+            records[idx] = {
+                "dialogue_id": turn["dialogue_id"],
+                "service": turn["service"],
+                "schemas_shown": shown,
+                "gold_in_prompt": turn["service"] in shown,
+                "gold": turn["gold_belief"],
+                "pred": pred,
+                "correct": exact_match(pred, turn["gold_belief"]),
+                "slot_precision": prec,
+                "slot_recall": rec,
+                "slot_f1": f1,
+            }
+            done += 1
+            if done % 50 == 0 or done == len(prepared):
+                jga_so_far = sum(r["correct"] for r in records if r) / done * 100
+                print(f"  [{done:>5}/{len(prepared)}] running JGA {jga_so_far:.1f}")
+
+    n = len(records)
+    summary = {
+        "mode": args.mode,
+        "deployment": args.deployment,
+        "split": args.split,
+        "n_turns": n,
+        "seed": args.seed,
+        "n_schemas": args.n_schemas,
+        "n_distractors": args.n_distractors,
+        "jga": round(sum(r["correct"] for r in records) / n * 100, 2),
+        "slot_f1": round(sum(r["slot_f1"] for r in records) / n * 100, 2),
+        "gold_in_prompt_rate": round(
+            sum(r["gold_in_prompt"] for r in records) / n * 100, 2
+        ),
+    }
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8"
+    )
+    with (args.output_dir / "turns.jsonl").open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    print(f"\n  JGA                 {summary['jga']:.1f}")
+    print(f"  Slot F1             {summary['slot_f1']:.1f}")
+    print(f"  Gold in prompt      {summary['gold_in_prompt_rate']:.1f}%")
+    print(f"\n[out] {args.output_dir}/summary.json  and  turns.jsonl")
+    return summary
+
+
+def main() -> None:
+    load_dotenv_if_present()
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--mode", choices=MODES, required=True)
+    ap.add_argument(
+        "--deployment", default=os.environ.get("DEPLOYMENT", "gpt-4.1-mini")
+    )
+    ap.add_argument("--endpoint", default=None, help="defaults to $AOAI_ENDPOINT")
+    ap.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    ap.add_argument("--split", default="test", choices=["train", "dev", "test"])
+    ap.add_argument("--n", type=int, default=200, help="turns to sample; 0 = all")
+    ap.add_argument("--n-schemas", type=int, default=1, help="how many to retrieve")
+    ap.add_argument("--n-distractors", type=int, default=2)
+    ap.add_argument("--concurrency", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--output-dir", type=Path, default=HERE / "results" / "run")
+    evaluate(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/finetuning/schemaraft-dst/fixtures/test/dialogues_001.json
+++ b/samples/python/finetuning/schemaraft-dst/fixtures/test/dialogues_001.json
@@ -1,0 +1,103 @@
+[
+  {
+    "dialogue_id": "fixture_0001",
+    "services": ["Restaurants_2"],
+    "turns": [
+      {
+        "speaker": "USER",
+        "utterance": "Find a mid-priced Italian restaurant for two in San Francisco.",
+        "frames": [
+          {
+            "service": "Restaurants_2",
+            "state": {
+              "active_intent": "FindRestaurants",
+              "requested_slots": [],
+              "slot_values": {
+                "category": ["Italian"],
+                "location": ["San Francisco"],
+                "price_range": ["moderate"],
+                "number_of_seats": ["2"]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "speaker": "SYSTEM",
+        "utterance": "What time would you like the table?",
+        "frames": [{"service": "Restaurants_2", "actions": []}]
+      },
+      {
+        "speaker": "USER",
+        "utterance": "7 pm tomorrow.",
+        "frames": [
+          {
+            "service": "Restaurants_2",
+            "state": {
+              "active_intent": "ReserveRestaurant",
+              "requested_slots": [],
+              "slot_values": {
+                "category": ["Italian"],
+                "location": ["San Francisco"],
+                "price_range": ["moderate"],
+                "number_of_seats": ["2"],
+                "time": ["7 pm"],
+                "date": ["tomorrow"]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "dialogue_id": "fixture_0002",
+    "services": ["Buses_3"],
+    "turns": [
+      {
+        "speaker": "USER",
+        "utterance": "I need a direct bus from Sacramento to Fresno on the 5th.",
+        "frames": [
+          {
+            "service": "Buses_3",
+            "state": {
+              "active_intent": "FindBus",
+              "requested_slots": [],
+              "slot_values": {
+                "from_city": ["Sacramento"],
+                "to_city": ["Fresno"],
+                "departure_date": ["2019-03-05"],
+                "category": ["direct"]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "speaker": "SYSTEM",
+        "utterance": "How many tickets do you need?",
+        "frames": [{"service": "Buses_3", "actions": []}]
+      },
+      {
+        "speaker": "USER",
+        "utterance": "Three tickets please.",
+        "frames": [
+          {
+            "service": "Buses_3",
+            "state": {
+              "active_intent": "BuyBusTicket",
+              "requested_slots": [],
+              "slot_values": {
+                "from_city": ["Sacramento"],
+                "to_city": ["Fresno"],
+                "departure_date": ["2019-03-05"],
+                "category": ["direct"],
+                "num_passengers": ["3"]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/samples/python/finetuning/schemaraft-dst/fixtures/test/schema.json
+++ b/samples/python/finetuning/schemaraft-dst/fixtures/test/schema.json
@@ -1,0 +1,68 @@
+[
+  {
+    "service_name": "Restaurants_2",
+    "description": "A leading provider for restaurant search and reservations",
+    "slots": [
+      {"name": "restaurant_name", "description": "Name of the restaurant", "is_categorical": false, "possible_values": []},
+      {"name": "date", "description": "Date for the reservation or the restaurant search", "is_categorical": false, "possible_values": []},
+      {"name": "time", "description": "Time for the reservation", "is_categorical": false, "possible_values": []},
+      {"name": "number_of_seats", "description": "Number of seats to reserve", "is_categorical": true, "possible_values": ["1", "2", "3", "4", "5", "6"]},
+      {"name": "location", "description": "City where the restaurant is located", "is_categorical": false, "possible_values": []},
+      {"name": "category", "description": "The cuisine of food served in the restaurant", "is_categorical": false, "possible_values": []},
+      {"name": "price_range", "description": "Price range of the restaurant", "is_categorical": true, "possible_values": ["cheap", "moderate", "pricey", "ultra high-end"]}
+    ],
+    "intents": [
+      {"name": "ReserveRestaurant", "description": "Reserve a table at a restaurant", "is_transactional": true, "required_slots": ["restaurant_name", "location", "time"], "optional_slots": {}, "result_slots": []},
+      {"name": "FindRestaurants", "description": "Find restaurants by location and cuisine", "is_transactional": false, "required_slots": ["category", "location"], "optional_slots": {}, "result_slots": []}
+    ]
+  },
+  {
+    "service_name": "Restaurants_1",
+    "description": "A leading provider for restaurant search and reservations",
+    "slots": [
+      {"name": "restaurant_name", "description": "Name of the restaurant", "is_categorical": false, "possible_values": []},
+      {"name": "date", "description": "Tentative date of restaurant reservation", "is_categorical": false, "possible_values": []},
+      {"name": "time", "description": "Tentative time of restaurant reservation", "is_categorical": false, "possible_values": []},
+      {"name": "party_size", "description": "Party size for a reservation", "is_categorical": true, "possible_values": ["1", "2", "3", "4", "5", "6"]},
+      {"name": "city", "description": "City where the restaurant is located", "is_categorical": false, "possible_values": []},
+      {"name": "cuisine", "description": "Cuisine of food served by the restaurant", "is_categorical": true, "possible_values": ["Mexican", "Chinese", "Indian", "American", "Italian"]},
+      {"name": "price_range", "description": "Price range for the restaurant", "is_categorical": true, "possible_values": ["cheap", "moderate", "expensive", "very expensive"]}
+    ],
+    "intents": [
+      {"name": "ReserveRestaurant", "description": "Book a table at a restaurant", "is_transactional": true, "required_slots": ["restaurant_name", "city"], "optional_slots": {}, "result_slots": []},
+      {"name": "FindRestaurants", "description": "Search for a restaurant by cuisine and city", "is_transactional": false, "required_slots": ["cuisine", "city"], "optional_slots": {}, "result_slots": []}
+    ]
+  },
+  {
+    "service_name": "Hotels_4",
+    "description": "Accommodation searching and booking portal",
+    "slots": [
+      {"name": "location", "description": "City or town where the accommodation is located", "is_categorical": false, "possible_values": []},
+      {"name": "number_of_rooms", "description": "Number of rooms to reserve", "is_categorical": true, "possible_values": ["1", "2", "3"]},
+      {"name": "check_in_date", "description": "Start date for the reservation", "is_categorical": false, "possible_values": []},
+      {"name": "stay_length", "description": "Number of nights of the stay", "is_categorical": false, "possible_values": []},
+      {"name": "star_rating", "description": "Star rating of the accommodation", "is_categorical": true, "possible_values": ["1", "2", "3", "4", "5"]},
+      {"name": "place_name", "description": "Name of the hotel or accommodation", "is_categorical": false, "possible_values": []}
+    ],
+    "intents": [
+      {"name": "ReserveHotel", "description": "Reserve rooms at a selected place of stay", "is_transactional": true, "required_slots": ["place_name", "location", "check_in_date"], "optional_slots": {}, "result_slots": []},
+      {"name": "SearchHotel", "description": "Search for a place of stay in a given city", "is_categorical": false, "is_transactional": false, "required_slots": ["location"], "optional_slots": {}, "result_slots": []}
+    ]
+  },
+  {
+    "service_name": "Buses_3",
+    "description": "Bus transportation search and booking",
+    "slots": [
+      {"name": "from_city", "description": "City where the journey originates", "is_categorical": false, "possible_values": []},
+      {"name": "to_city", "description": "City where the journey ends", "is_categorical": false, "possible_values": []},
+      {"name": "departure_date", "description": "Date of departure", "is_categorical": false, "possible_values": []},
+      {"name": "departure_time", "description": "Time of departure", "is_categorical": false, "possible_values": []},
+      {"name": "num_passengers", "description": "Number of tickets for the trip", "is_categorical": true, "possible_values": ["1", "2", "3", "4", "5"]},
+      {"name": "category", "description": "Number of stops on the route", "is_categorical": true, "possible_values": ["direct", "one-stop"]}
+    ],
+    "intents": [
+      {"name": "BuyBusTicket", "description": "Buy tickets for a bus journey", "is_transactional": true, "required_slots": ["from_city", "to_city", "departure_date"], "optional_slots": {}, "result_slots": []},
+      {"name": "FindBus", "description": "Find a bus journey between two cities", "is_transactional": false, "required_slots": ["from_city", "to_city"], "optional_slots": {}, "result_slots": []}
+    ]
+  }
+]

--- a/samples/python/finetuning/schemaraft-dst/foundry_client.py
+++ b/samples/python/finetuning/schemaraft-dst/foundry_client.py
@@ -1,0 +1,69 @@
+"""Keyless Microsoft Foundry client.
+
+Auth is `DefaultAzureCredential` only - there is no API-key path in this sample.
+Locally that resolves to your `az login` session; on Azure it resolves to the
+managed identity. Either way no secret is ever written to disk.
+
+The bearer token is cached until shortly before expiry. Without that, the OpenAI
+SDK calls the token provider on every request, which under
+DefaultAzureCredential spawns an `az account get-access-token` subprocess each
+time - slow enough to dominate a long evaluation run.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+from azure.identity import DefaultAzureCredential
+from openai import OpenAI
+
+SCOPE = "https://ai.azure.com/.default"
+
+
+class _CachedBearerTokenProvider:
+    def __init__(self, scope: str = SCOPE, refresh_margin_seconds: int = 300):
+        self._scope = scope
+        self._margin = refresh_margin_seconds
+        self._credential = DefaultAzureCredential(process_timeout=60)
+        self._token: str | None = None
+        self._expires_on = 0.0
+
+    def __call__(self) -> str:
+        if self._token and time.time() <= self._expires_on - self._margin:
+            return self._token
+        last_exc: Exception | None = None
+        for attempt in range(1, 4):
+            try:
+                tok = self._credential.get_token(self._scope)
+                self._token = tok.token
+                self._expires_on = float(tok.expires_on)
+                return self._token
+            except Exception as exc:  # transient DNS / CLI subprocess blips
+                last_exc = exc
+                time.sleep(2**attempt)
+        if self._token:
+            return self._token
+        raise RuntimeError(
+            "could not acquire an Azure token; run `az login`"
+        ) from last_exc
+
+
+def resolve_endpoint(endpoint: str | None = None) -> str:
+    """Return the OpenAI-v1 base URL for the Foundry resource."""
+    ep = endpoint or os.environ.get("AOAI_ENDPOINT")
+    if not ep:
+        raise RuntimeError(
+            "set AOAI_ENDPOINT (e.g. https://<your-resource>.openai.azure.com) "
+            "in your environment or .env"
+        )
+    ep = ep.rstrip("/")
+    if not ep.startswith("https://"):
+        raise RuntimeError(f"AOAI_ENDPOINT must be an https URL, got {ep!r}")
+    return ep if ep.endswith("/openai/v1") else f"{ep}/openai/v1"
+
+
+def make_client(endpoint: str | None = None) -> OpenAI:
+    return OpenAI(
+        base_url=resolve_endpoint(endpoint) + "/",
+        api_key=_CachedBearerTokenProvider(),
+    )

--- a/samples/python/finetuning/schemaraft-dst/goldpresent_strata.py
+++ b/samples/python/finetuning/schemaraft-dst/goldpresent_strata.py
@@ -1,0 +1,105 @@
+"""Separate a retrieval failure from a schema-following failure.
+
+    python goldpresent_strata.py --results results/retdist
+
+Splits the turns from an `eval_jga.py --mode retrieved_distractor` run into the
+subset where the correct schema really was in the prompt and the subset where it
+was not, then reports JGA on each.
+
+Read it this way:
+
+* Low JGA on the gold-absent stratum is expected and uninteresting. The model
+  was never shown the answer.
+* Low JGA on the **gold-present** stratum is the finding. The correct schema was
+  sitting in the context and the model still got the turn wrong, which means
+  better retrieval cannot fix it.
+* Abstention rate on the gold-absent stratum tells you whether the model
+  degrades safely. Emitting `{}` is the correct behaviour there; inventing slots
+  from a distractor schema is not.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_records(results_dir: Path) -> list[dict]:
+    path = results_dir / "turns.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} not found - run eval_jga.py with --output-dir {results_dir}"
+        )
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def summarise(records: list[dict]) -> dict:
+    present = [r for r in records if r["gold_in_prompt"]]
+    absent = [r for r in records if not r["gold_in_prompt"]]
+
+    def jga(rows: list[dict]) -> float | None:
+        return (
+            round(sum(r["correct"] for r in rows) / len(rows) * 100, 2)
+            if rows
+            else None
+        )
+
+    abstained = sum(1 for r in absent if not r["pred"])
+    return {
+        "n_turns": len(records),
+        "jga_overall": jga(records),
+        "n_gold_present": len(present),
+        "gold_present_rate": round(len(present) / len(records) * 100, 2)
+        if records
+        else None,
+        "jga_gold_present": jga(present),
+        "n_gold_absent": len(absent),
+        "jga_gold_absent": jga(absent),
+        "abstention_rate_gold_absent": round(abstained / len(absent) * 100, 2)
+        if absent
+        else None,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--results", type=Path, required=True, help="an eval_jga.py --output-dir"
+    )
+    args = ap.parse_args()
+
+    s = summarise(load_records(args.results))
+
+    print(f"\nturns                            {s['n_turns']:,}")
+    print(f"overall JGA                      {s['jga_overall']:.1f}\n")
+    print(
+        f"gold schema IN the prompt        {s['n_gold_present']:,} turns "
+        f"({s['gold_present_rate']:.1f}%)"
+    )
+    print(
+        f"  JGA on that stratum            {s['jga_gold_present']:.1f}   <-- the finding"
+    )
+    print(f"\ngold schema NOT in the prompt    {s['n_gold_absent']:,} turns")
+    if s["n_gold_absent"]:
+        print(f"  JGA on that stratum            {s['jga_gold_absent']:.1f}")
+        print(
+            f"  correctly abstained            {s['abstention_rate_gold_absent']:.1f}%"
+        )
+
+    print("\nIf the gold-present number is far below the oracle run, the model is not")
+    print("failing to FIND the schema. It is failing to FOLLOW it, falling back on")
+    print("slot inventories memorised during pre-training.")
+
+    out = args.results / "strata.json"
+    out.write_text(json.dumps(s, indent=2), encoding="utf-8")
+    print(f"\n[out] {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/python/finetuning/schemaraft-dst/requirements.txt
+++ b/samples/python/finetuning/schemaraft-dst/requirements.txt
@@ -1,0 +1,5 @@
+# Keyless auth to Microsoft Foundry (DefaultAzureCredential). No API keys.
+azure-identity>=1.15
+openai>=1.30
+
+# Everything else - BM25 retrieval, SGD download, metrics - is standard library.

--- a/samples/python/finetuning/schemaraft-dst/sample.yaml
+++ b/samples/python/finetuning/schemaraft-dst/sample.yaml
@@ -1,0 +1,8 @@
+name: Deployment-Faithful Schema Evaluation for Dialogue State Tracking (Python)
+description: >
+  Measure how much accuracy a schema-guided DST model loses when schemas are
+  retrieved instead of handed to it. Reproduces the oracle-schema vs.
+  retrieval-with-distractors gap on SGD, and ships the SchemaRAFT fine-tuning
+  recipe that recovers most of it.
+build: "pip install -r requirements.txt"
+validate: "python selftest.py"

--- a/samples/python/finetuning/schemaraft-dst/schema_retriever.py
+++ b/samples/python/finetuning/schemaraft-dst/schema_retriever.py
@@ -1,0 +1,99 @@
+"""BM25 retrieval over the schema registry, plus distractor sampling.
+
+BM25 is implemented inline rather than pulled from a package so the exact
+ranking function is auditable and the sample has one less dependency. Character
+n-grams beat word tokens here because SGD slot names run together
+(``restaurant_name`` vs ``restaurant name``) and the query is raw dialogue text.
+"""
+from __future__ import annotations
+
+import math
+import random
+from collections import Counter
+
+from sgd_data import schema_to_text
+
+
+def char_ngram_tokenize(text: str, lo: int = 3, hi: int = 5) -> list[str]:
+    text = text.lower()
+    toks: list[str] = []
+    n_chars = len(text)
+    for n in range(lo, hi + 1):
+        if n_chars < n:
+            break
+        toks.extend(text[i : i + n] for i in range(n_chars - n + 1))
+    return toks
+
+
+class BM25Okapi:
+    def __init__(
+        self, corpus_tokens: list[list[str]], k1: float = 1.5, b: float = 0.75
+    ):
+        self.k1, self.b = k1, b
+        self.n_docs = len(corpus_tokens)
+        self.doc_len = [len(d) for d in corpus_tokens]
+        self.avgdl = (sum(self.doc_len) / self.n_docs) if self.n_docs else 0.0
+        self.doc_freqs = [Counter(d) for d in corpus_tokens]
+        df: Counter = Counter()
+        for freqs in self.doc_freqs:
+            df.update(freqs.keys())
+        self.idf = {
+            term: math.log(1.0 + (self.n_docs - n + 0.5) / (n + 0.5))
+            for term, n in df.items()
+        }
+
+    def get_scores(self, query_tokens: list[str]) -> list[float]:
+        scores = [0.0] * self.n_docs
+        if self.avgdl == 0.0:
+            return scores
+        for term in set(query_tokens):
+            idf = self.idf.get(term)
+            if idf is None:
+                continue
+            for i, freqs in enumerate(self.doc_freqs):
+                f = freqs.get(term, 0)
+                if not f:
+                    continue
+                denom = f + self.k1 * (
+                    1 - self.b + self.b * self.doc_len[i] / self.avgdl
+                )
+                scores[i] += idf * (f * (self.k1 + 1)) / denom
+        return scores
+
+
+class SchemaRetriever:
+    """Ranks every schema in the registry against the dialogue history."""
+
+    def __init__(self, schema_map: dict[str, dict]):
+        self.schema_map = schema_map
+        self.service_ids = list(schema_map)
+        docs = [schema_to_text(schema_map[s]) for s in self.service_ids]
+        self._bm25 = BM25Okapi([char_ngram_tokenize(d) for d in docs])
+
+    @staticmethod
+    def _as_text(history: list[str] | str) -> str:
+        return "\n".join(history) if isinstance(history, list) else history
+
+    def rank(self, history: list[str] | str) -> list[tuple[str, float]]:
+        scores = self._bm25.get_scores(char_ngram_tokenize(self._as_text(history)))
+        order = sorted(range(len(scores)), key=lambda i: -scores[i])
+        return [(self.service_ids[i], scores[i]) for i in order]
+
+    def retrieve(self, history: list[str] | str, k: int = 1) -> list[dict]:
+        if k <= 0:
+            return []
+        return [self.schema_map[s] for s, _ in self.rank(history)[:k]]
+
+    def sample_distractors(
+        self,
+        exclude: set[str],
+        n: int,
+        rng: random.Random,
+    ) -> list[dict]:
+        """Uniform random schemas from the registry, excluding what is already shown."""
+        if n <= 0:
+            return []
+        pool = [s for s in self.service_ids if s not in exclude]
+        if not pool:
+            return []
+        return [self.schema_map[s] for s in rng.sample(pool, min(n, len(pool)))]

--- a/samples/python/finetuning/schemaraft-dst/selftest.py
+++ b/samples/python/finetuning/schemaraft-dst/selftest.py
@@ -1,0 +1,271 @@
+"""Offline smoke test. No network, no Azure, no tokens spent.
+
+    python selftest.py
+
+Runs the retrieval, prompt-assembly, parsing, scoring, training-data and
+stratification paths against the bundled fixtures in `fixtures/test/`, so you
+can tell a broken checkout apart from a broken deployment before step 2.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+from pathlib import Path
+
+from build_prompts import (
+    build_messages,
+    exact_match,
+    parse_belief_json,
+    select_schemas,
+    slot_f1,
+)
+from build_sft_data import build as build_sft
+from goldpresent_strata import summarise
+from schema_retriever import SchemaRetriever
+from sgd_data import load_schema_map, load_turns, schema_to_text
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SPLIT_DIR = FIXTURES / "test"
+
+_failures: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok    {name}")
+    else:
+        print(f"  FAIL  {name}{'  -> ' + detail if detail else ''}")
+        _failures.append(name)
+
+
+def test_data_layer() -> tuple[dict, list[dict]]:
+    print("\n[1] data layer")
+    schema_map = load_schema_map(SPLIT_DIR)
+    turns = load_turns(SPLIT_DIR, seed=42)
+    check("schema registry loads", len(schema_map) == 4, f"got {len(schema_map)}")
+    check("turns extracted", len(turns) == 4, f"got {len(turns)}")
+    check(
+        "gold belief is flattened and lowercased",
+        turns[0]["gold_belief"].get("location") == "san francisco",
+        str(turns[0]["gold_belief"]),
+    )
+    check(
+        "belief state is cumulative",
+        set(turns[1]["gold_belief"]) > set(turns[0]["gold_belief"]),
+    )
+    text = schema_to_text(schema_map["Restaurants_2"])
+    check(
+        "schema serialises with slots and intents",
+        "price_range" in text and "ReserveRestaurant" in text,
+    )
+    return schema_map, turns
+
+
+def test_retrieval(schema_map: dict, turns: list[dict]) -> SchemaRetriever:
+    print("\n[2] retrieval")
+    r = SchemaRetriever(schema_map)
+    ranked = r.rank(turns[0]["history"])
+    check("ranking covers the whole registry", len(ranked) == len(schema_map))
+    check(
+        "scores are sorted descending",
+        all(ranked[i][1] >= ranked[i + 1][1] for i in range(len(ranked) - 1)),
+    )
+    check(
+        "restaurant dialogue retrieves a restaurant schema",
+        ranked[0][0].startswith("Restaurants_"),
+        f"top1={ranked[0][0]}",
+    )
+    check(
+        "bus dialogue retrieves the bus schema",
+        r.rank(turns[2]["history"])[0][0] == "Buses_3",
+    )
+
+    rng = random.Random(0)
+    d = r.sample_distractors({"Restaurants_2"}, 2, rng)
+    check(
+        "distractors exclude the gold service",
+        len(d) == 2 and all(s["service_name"] != "Restaurants_2" for s in d),
+    )
+    return r
+
+
+def test_prompt_modes(schema_map: dict, turns: list[dict], r: SchemaRetriever) -> None:
+    print("\n[3] prompt modes")
+    t = turns[0]
+
+    def pick(mode: str, seed: int = 42, n_distractors: int = 2) -> list[str]:
+        schemas = select_schemas(
+            t["history"],
+            t["service"],
+            schema_map,
+            mode,
+            r,
+            1,
+            n_distractors,
+            random.Random(seed),
+        )
+        return [s["service_name"] for s in schemas]
+
+    check("mode=none shows no schema", pick("none") == [])
+    check(
+        "mode=oracle shows exactly the gold schema", pick("oracle") == ["Restaurants_2"]
+    )
+    check("mode=retrieved shows one schema", len(pick("retrieved")) == 1)
+
+    shown = pick("retrieved_distractor")
+    check("retrieved_distractor shows 1 + n_distractors", len(shown) == 3, str(shown))
+    check("schemas shown are distinct", len(set(shown)) == len(shown), str(shown))
+    check("same seed reproduces the same prompt", shown == pick("retrieved_distractor"))
+    check(
+        "different seed reshuffles",
+        any(pick("retrieved_distractor", seed=s) != shown for s in (1, 2, 3, 7)),
+    )
+
+    msgs = build_messages(t["history"], t["service"], [schema_map["Restaurants_2"]])
+    check("messages are system+user", [m["role"] for m in msgs] == ["system", "user"])
+    check(
+        "gold schema reaches the system prompt", "Restaurants_2" in msgs[0]["content"]
+    )
+    check("history reaches the user prompt", "Italian" in msgs[1]["content"])
+    check(
+        "no-schema prompt has no schema block",
+        "Service schemas"
+        not in build_messages(t["history"], t["service"], [])[0]["content"],
+    )
+
+
+def test_parsing_and_metrics() -> None:
+    print("\n[4] parsing and metrics")
+    check("plain json", parse_belief_json('{"city": "SF"}') == {"city": "sf"})
+    check(
+        "markdown fenced",
+        parse_belief_json('```json\n{"city": "SF"}\n```') == {"city": "sf"},
+    )
+    check(
+        "json with trailing prose",
+        parse_belief_json('Here you go: {"city": "SF"} hope that helps')
+        == {"city": "sf"},
+    )
+    check("empty state", parse_belief_json("{}") == {})
+    check("unparseable becomes empty", parse_belief_json("I am not sure.") == {})
+    check("non-dict becomes empty", parse_belief_json("[1, 2, 3]") == {})
+
+    gold = {"city": "sf", "cuisine": "italian"}
+    check(
+        "exact match is exact", exact_match({"city": "sf", "cuisine": "italian"}, gold)
+    )
+    check(
+        "one wrong slot fails the turn",
+        not exact_match({"city": "sf", "cuisine": "mexican"}, gold),
+    )
+    check(
+        "an extra slot fails the turn",
+        not exact_match({"city": "sf", "cuisine": "italian", "time": "7 pm"}, gold),
+    )
+    p, rec, f1 = slot_f1({"city": "sf", "cuisine": "mexican"}, gold)
+    check(
+        "slot f1 gives partial credit",
+        abs(p - 0.5) < 1e-9 and abs(f1 - 0.5) < 1e-9,
+        f"p={p} r={rec} f1={f1}",
+    )
+
+
+def test_training_data() -> None:
+    print("\n[5] training data")
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "train.jsonl"
+
+        def run(frac: float) -> list[dict]:
+            build_sft(
+                argparse.Namespace(
+                    data_dir=FIXTURES,
+                    split="test",
+                    n_distractors=2,
+                    gold_absent_frac=frac,
+                    max_dialogues=None,
+                    seed=42,
+                    out=out,
+                )
+            )
+            return [json.loads(x) for x in out.read_text(encoding="utf-8").splitlines()]
+
+        rows = run(0.0)
+        check("one training row per turn", len(rows) == 4, f"got {len(rows)}")
+        roles = [m["role"] for m in rows[0]["messages"]]
+        check(
+            "chat format is system/user/assistant",
+            roles == ["system", "user", "assistant"],
+            str(roles),
+        )
+        check(
+            "assistant turn is valid json",
+            isinstance(json.loads(rows[0]["messages"][-1]["content"]), dict),
+        )
+        check(
+            "gold_absent_frac=0 always labels a real state",
+            all(json.loads(r["messages"][-1]["content"]) for r in rows),
+        )
+        check(
+            "prompt carries 3 schemas",
+            rows[0]["messages"][0]["content"].count("Service: ") == 3,
+        )
+
+        rows = run(1.0)
+        check(
+            "gold_absent_frac=1 labels every row with {}",
+            all(json.loads(r["messages"][-1]["content"]) == {} for r in rows),
+        )
+        check(
+            "gold-absent rows hide the correct schema",
+            all(
+                "Service: Restaurants_2" not in r["messages"][0]["content"]
+                for r in rows[:2]
+            ),
+        )
+
+
+def test_strata() -> None:
+    print("\n[6] stratification")
+    records = (
+        [{"gold_in_prompt": True, "correct": True, "pred": {"a": "1"}}] * 3
+        + [{"gold_in_prompt": True, "correct": False, "pred": {"a": "2"}}] * 7
+        + [{"gold_in_prompt": False, "correct": False, "pred": {}}] * 6
+        + [{"gold_in_prompt": False, "correct": False, "pred": {"a": "3"}}] * 4
+    )
+    s = summarise(records)
+    check("overall jga", s["jga_overall"] == 15.0, str(s["jga_overall"]))
+    check(
+        "gold-present jga is conditional, not overall",
+        s["jga_gold_present"] == 30.0,
+        str(s["jga_gold_present"]),
+    )
+    check("gold-present rate", s["gold_present_rate"] == 50.0)
+    check(
+        "abstention counted only on gold-absent turns",
+        s["abstention_rate_gold_absent"] == 60.0,
+        str(s["abstention_rate_gold_absent"]),
+    )
+
+
+def main() -> int:
+    print("SchemaRAFT offline selftest (no Azure calls)")
+    schema_map, turns = test_data_layer()
+    retriever = test_retrieval(schema_map, turns)
+    test_prompt_modes(schema_map, turns, retriever)
+    test_parsing_and_metrics()
+    test_training_data()
+    test_strata()
+
+    print()
+    if _failures:
+        print(f"FAILED: {len(_failures)} check(s): {', '.join(_failures)}")
+        return 1
+    print("All checks passed. You are ready for step 1.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/python/finetuning/schemaraft-dst/sgd_data.py
+++ b/samples/python/finetuning/schemaraft-dst/sgd_data.py
@@ -1,0 +1,113 @@
+"""Load SGD and turn it into dialogue-state-tracking examples.
+
+The serialisation here is the single source of truth: the retriever indexes
+schemas through `schema_to_text`, and both evaluation and training render them
+the same way, so nothing shifts between the two.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+DEFAULT_DATA_DIR = Path(__file__).resolve().parent / "data" / "sgd"
+
+
+def load_schema_map(split_dir: Path) -> dict[str, dict]:
+    """service_name -> schema dict. This is the registry the retriever searches."""
+    entries = json.loads((split_dir / "schema.json").read_text(encoding="utf-8"))
+    return {e["service_name"]: e for e in entries}
+
+
+def schema_to_text(svc: dict) -> str:
+    lines = [
+        f"Service: {svc['service_name']}",
+        f"  {svc['description']}",
+        "  Slots:",
+    ]
+    for slot in svc.get("slots", []):
+        kind = "categorical" if slot.get("is_categorical") else "free-text"
+        vals = ""
+        if slot.get("is_categorical") and slot.get("possible_values"):
+            vals = f" (values: {', '.join(slot['possible_values'][:8])})"
+        lines.append(f"    - {slot['name']} [{kind}]{vals}: {slot['description']}")
+    lines.append("  Intents:")
+    for intent in svc.get("intents", []):
+        req = intent.get("required_slots", [])
+        lines.append(
+            f"    - {intent['name']}: {intent['description']}"
+            + (f" | required: {', '.join(req)}" if req else "")
+        )
+    return "\n".join(lines)
+
+
+def _flatten_slot_values(slot_values: dict[str, list[str]]) -> dict[str, str]:
+    """SGD stores {slot: [variant, ...]}; take the first (canonical) variant."""
+    return {k: v[0] for k, v in slot_values.items() if v}
+
+
+def _normalise(belief: dict[str, str]) -> dict[str, str]:
+    return {k: str(v).strip().lower() for k, v in belief.items()}
+
+
+def load_turns(
+    split_dir: Path,
+    max_dialogues: int | None = None,
+    seed: int = 42,
+) -> list[dict]:
+    """Return DST turns: {history, service, gold_belief}.
+
+    One turn per USER utterance that carries a non-empty cumulative belief
+    state. Turns with an empty gold state are dropped, which is what the
+    official SGD evaluator does for joint goal accuracy.
+    """
+    import random
+
+    dialogues: list[dict] = []
+    for f in sorted(split_dir.glob("dialogues_*.json")):
+        dialogues.extend(json.loads(f.read_text(encoding="utf-8")))
+    if not dialogues:
+        raise FileNotFoundError(
+            f"no dialogues_*.json under {split_dir} - run download_sgd.py first"
+        )
+
+    if max_dialogues and max_dialogues < len(dialogues):
+        dialogues = random.Random(seed).sample(dialogues, max_dialogues)
+
+    turns: list[dict] = []
+    for dlg in dialogues:
+        history: list[str] = []
+        services = dlg.get("services") or ["unknown"]
+        service = services[0]
+
+        for turn in dlg["turns"]:
+            label = "User" if turn["speaker"] == "USER" else "System"
+            history.append(f"{label}: {turn['utterance'].strip()}")
+            if turn["speaker"] != "USER":
+                continue
+
+            belief: dict[str, str] = {}
+            for frame in turn.get("frames", []):
+                belief.update(
+                    _flatten_slot_values(frame.get("state", {}).get("slot_values", {}))
+                )
+            if not belief:
+                continue
+
+            turns.append(
+                {
+                    "dialogue_id": dlg.get("dialogue_id", ""),
+                    "history": list(history),
+                    "service": service,
+                    "gold_belief": _normalise(belief),
+                }
+            )
+    return turns
+
+
+def resolve_split(data_dir: Path, split: str) -> Path:
+    d = data_dir / split
+    if not d.exists():
+        raise FileNotFoundError(
+            f"{d} not found - run: python download_sgd.py --splits {split}"
+        )
+    return d

--- a/samples/python/finetuning/schemaraft-dst/submit_finetune.py
+++ b/samples/python/finetuning/schemaraft-dst/submit_finetune.py
@@ -1,0 +1,134 @@
+"""Submit and monitor a SchemaRAFT fine-tuning job on Microsoft Foundry.
+
+    python submit_finetune.py --train-file data/schemaraft_train.jsonl \
+                              --val-file   data/schemaraft_val.jsonl
+
+State is written to `finetune_job.json`, so `--resume` reattaches to a running
+job instead of paying for a second one.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+from eval_jga import load_dotenv_if_present
+from foundry_client import make_client
+
+HERE = Path(__file__).resolve().parent
+STATE_PATH = HERE / "finetune_job.json"
+TERMINAL = {"succeeded", "failed", "cancelled"}
+
+
+def upload(client, path: Path) -> str:
+    print(f"[upload] {path.name} ({path.stat().st_size / 1e6:.1f} MB)")
+    with path.open("rb") as f:
+        resp = client.files.create(file=f, purpose="fine-tune")
+    print(f"         id={resp.id} status={resp.status}")
+    return resp.id
+
+
+def wait_processed(client, file_ids: list[str], timeout: int = 900) -> None:
+    deadline = time.time() + timeout
+    pending = set(file_ids)
+    while pending and time.time() < deadline:
+        for fid in list(pending):
+            info = client.files.retrieve(fid)
+            if info.status == "processed":
+                pending.discard(fid)
+            elif info.status == "error":
+                raise RuntimeError(f"file {fid} failed validation: {info}")
+        if pending:
+            print(f"[wait] {len(pending)} file(s) still processing")
+            time.sleep(10)
+    if pending:
+        raise TimeoutError(f"files not processed within {timeout}s: {pending}")
+    print("[ok] files processed")
+
+
+def poll(client, job_id: str, interval: int = 60) -> str | None:
+    print(f"[poll] watching {job_id} (every {interval}s; Ctrl-C is safe, use --resume)")
+    t0 = time.time()
+    while True:
+        job = client.fine_tuning.jobs.retrieve(job_id)
+        print(
+            f"  t={(time.time() - t0) / 60:5.1f}m  status={job.status}  "
+            f"trained_tokens={getattr(job, 'trained_tokens', None)}"
+        )
+        if job.status in TERMINAL:
+            if job.status != "succeeded":
+                raise RuntimeError(
+                    f"job ended with status={job.status}: "
+                    f"{getattr(job, 'error', None)}"
+                )
+            return job.fine_tuned_model
+        time.sleep(interval)
+
+
+def main() -> None:
+    load_dotenv_if_present()
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--train-file", type=Path, default=HERE / "data" / "schemaraft_train.jsonl"
+    )
+    ap.add_argument("--val-file", type=Path, default=None)
+    ap.add_argument(
+        "--base-model", default=os.environ.get("BASE_MODEL", "gpt-4.1-mini-2025-04-14")
+    )
+    ap.add_argument("--suffix", default="schemaraft")
+    ap.add_argument("--epochs", type=int, default=3)
+    ap.add_argument("--endpoint", default=None)
+    ap.add_argument(
+        "--resume", action="store_true", help="reattach to the saved job id"
+    )
+    args = ap.parse_args()
+
+    client = make_client(args.endpoint)
+    state = (
+        json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        if STATE_PATH.exists()
+        else {}
+    )
+
+    if args.resume and state.get("job_id"):
+        job_id = state["job_id"]
+    else:
+        ids = [upload(client, args.train_file)]
+        kwargs = {"training_file": ids[0]}
+        if args.val_file:
+            ids.append(upload(client, args.val_file))
+            kwargs["validation_file"] = ids[1]
+        wait_processed(client, ids)
+
+        print(f"[job] base={args.base_model} suffix={args.suffix} epochs={args.epochs}")
+        job = client.fine_tuning.jobs.create(
+            model=args.base_model,
+            suffix=args.suffix,
+            method={
+                "type": "supervised",
+                "supervised": {"hyperparameters": {"n_epochs": args.epochs}},
+            },
+            **kwargs,
+        )
+        job_id = job.id
+        state = {"job_id": job_id, "base_model": args.base_model}
+        STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        print(f"      job_id={job_id}  (saved to {STATE_PATH.name})")
+
+    model = poll(client, job_id)
+    state["fine_tuned_model"] = model
+    STATE_PATH.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    print(f"\n[done] fine-tuned model: {model}")
+    print("Deploy it in the Foundry portal, then re-run:")
+    print(
+        "  python eval_jga.py --mode retrieved_distractor --deployment <deployment-name>"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Adds one new sample: `samples/python/finetuning/schemaraft-dst`. No existing files are touched.

## Why

Schema-guided DST samples usually hand the model the correct schema. Deployments don't -- the schema has to be retrieved, and distractors come with it. This sample makes that gap measurable and then closes it.

The included scripts reproduce, on the public SGD dataset:

- an oracle-schema baseline vs. retrieval-with-distractors, isolating how much accuracy is lost to schema following rather than retrieval
- a gold-present stratification, so the metric separates `the retriever missed` from `the model ignored what it was given`
- the SchemaRAFT fine-tuning recipe (SFT on retrieval-shaped prompts, including gold-absent rows that teach abstention), submitted through Microsoft Foundry

Auth is `DefaultAzureCredential` only -- there is no API-key path in this sample.

## Local validation

- `pip install -r requirements.txt`
- `python selftest.py` -- all checks pass, offline, on the checked-in fixtures under `fixtures/test/`. Covers schema retrieval, prompt construction, JGA/slot-F1 scoring, training-data generation, and gold-present stratification.

The full SGD corpus is not committed; `download_sgd.py` fetches it from Google Research on demand and `data/` is gitignored.

## Notes

Follows the conventions of the sibling `abo-rl-headroom` sample: same `sample.yaml` shape with `build` and `validate` keys, requirements pinned by lower bound, README structured as numbered steps.
