### PR TITLE
docs: add sample creation quick guide

### DIFF
--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -65,8 +65,13 @@ live_service_validation:
   command: >-
     python run_sample.py --assert-response
   required_env:
-    - AZURE_OPENAI_ENDPOINT
-    - MODEL_DEPLOYMENT
+    - FOUNDRY_PROJECT_ENDPOINT
+    - FOUNDRY_MODEL_DEPLOYMENT
+  substitutions:
+    - file: run_sample.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
 ```
 
 The contract is:
@@ -90,6 +95,18 @@ The contract is:
 - `live_service_validation.required_env` is optional. When present, it must be a list of valid
   environment-variable names. Every listed variable must be non-empty or the
   validator returns infrastructure error (`2`) before executing sample code.
+- `live_service_validation.substitutions` is optional. Use it when source files
+  intentionally retain copy/paste instructional placeholders, such as
+  `"your_project_endpoint"`, but the validation caller owns the real value.
+  Each substitution names a file inside the sample directory and one or more
+  `placeholder` to `env` replacements. The validator requires each environment
+  variable to be non-empty and replaces every exact placeholder occurrence in
+  the workflow checkout before running the live-service command. It returns
+  infrastructure error (`2`) if a target is outside the sample directory,
+  missing, malformed, or lacks the placeholder. All substitutions are
+  validated and applied in memory before any file is written, so a rejected
+  declaration never leaves a partial rewrite. Target files must be regular,
+  non-symlinked text files without NUL bytes.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
   or `false` whenever live-service validation is declared. The validator
   passes it through but never provisions resources itself. Current repository
@@ -110,8 +127,24 @@ The contract is:
 
 The validator rejects the legacy `l4` key with a migration message. It also rejects
 a scalar `live_service_validation`, a missing/non-string/empty `command`, a non-list
-`required_env`, invalid variable names, malformed YAML, and missing declared
-environment inputs as infrastructure errors.
+`required_env`, invalid variable names, malformed YAML, invalid substitution
+declarations, and missing declared environment inputs as infrastructure errors.
+
+## Daily cadence environment variables
+
+The daily cadence's live-service job provides these non-secret configuration
+variables to every declared live-service command:
+
+| Variable | Purpose |
+|---|---|
+| `FOUNDRY_PROJECT_ENDPOINT` | The existing warm Microsoft Foundry project endpoint. |
+| `FOUNDRY_MODEL_DEPLOYMENT` | The deployment name in that project. |
+| `SKIP_PROVISION` | Always `true`; the cadence uses an existing warm project and never provisions resources. |
+
+Use the `FOUNDRY_` names for new sample metadata. The older
+`AZURE_AI_PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT` aliases remain available for
+backward compatibility. The job authenticates through GitHub/Entra OIDC; it
+does not expose credentials as sample environment variables.
 
 ## Caller responsibilities
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -42,9 +42,16 @@ is named `L4-validation` only because that legacy external identifier is part
 of the GitHub/Entra OIDC configuration. `L4` is not a current validation
 concept.
 
-See the [per-sample validation contract](scripts/validate-sample.README.md) for
-local commands, Build-readiness behavior, Live-service metadata, and result
-classification.
+Live-service commands receive `FOUNDRY_PROJECT_ENDPOINT`,
+`FOUNDRY_MODEL_DEPLOYMENT`, and `SKIP_PROVISION=true`. The older
+`AZURE_AI_PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT` aliases remain available for
+backward compatibility; new metadata should use the `FOUNDRY_` names.
+
+See the [quick guide to creating and validating samples](../CREATE_SAMPLE.md)
+for the minimum sample metadata and [per-sample validation
+contract](scripts/validate-sample.README.md) for local commands, Build-readiness
+behavior, Live-service metadata (including substitutions), available
+environment variables, and result classification.
 
 ## Results and report
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Contributors should always submit publishable changes through a public same-repo
 1. **Create a branch in this repository.** Use a same-repository branch for all sample changes.
 2. **Make a focused change.** Keep each pull request scoped to one sample, fix, or related set of updates. Follow the conventions in the surrounding sample.
 3. **Respect file ownership.** Review [CODEOWNERS](.github/CODEOWNERS) before editing. The listed owners receive review requests when their files change; CODEOWNERS routing does not itself require an approving review.
-4. **Validate locally.** Run the setup, build, test, or sample-specific validation documented by the affected sample. For metadata-bearing samples, use the [per-sample validation contract](.github/scripts/validate-sample.README.md) as the source for Build-readiness behavior and Live-service opt-in. Never commit credentials, local environment files, or generated secrets.
+4. **Validate locally.** Run the setup, build, test, or sample-specific validation documented by the affected sample. For metadata-bearing samples, start with the [quick guide to creating and validating samples](CREATE_SAMPLE.md); see the [per-sample validation contract](.github/scripts/validate-sample.README.md) for Build-readiness behavior, Live-service opt-in, substitutions, and available validation environment variables. Never commit credentials, local environment files, or generated secrets.
 5. **Open a pull request against `main`.** In the pull request description, explain what changed, why it changed, and the local validation you ran. Link the relevant issue when one exists.
 
 ### Pull request checks

--- a/CREATE_SAMPLE.md
+++ b/CREATE_SAMPLE.md
@@ -31,14 +31,28 @@ validate: "python -m py_compile *.py"
 live_service_validation:
   command: "python main.py"
   required_env:
-    - AZURE_AI_PROJECT_ENDPOINT
-    - MODEL_DEPLOYMENT
+    - FOUNDRY_PROJECT_ENDPOINT
+    - FOUNDRY_MODEL_DEPLOYMENT
+```
+
+For completeness, here is a full `sample.yaml` as it looks for a real quickstart sample:
+
+```yaml
+name: Quickstart Create Agent
+description: Basic quickstart sample demonstrating Microsoft Foundry agent creation.
+
+build: "pip install -r requirements.txt"
+validate: "python -m py_compile *.py"
+live_service_validation:
+  command: "python quickstart-create-agent.py"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
 ```
 
 ### How Full Runs Process This:
 - **Build Readiness:** Always runs build/compilation checks on PR touches and daily cadence.
 - **Live-Service Run:** Runs `live_service_validation.command` only if the `live_service_validation` section is present in `sample.yaml`.
-- **Environment variables:** The daily cadence provides both `AZURE_AI_PROJECT_ENDPOINT`/`MODEL_DEPLOYMENT` and the equivalent `FOUNDRY_PROJECT_ENDPOINT`/`FOUNDRY_MODEL_DEPLOYMENT` aliases, so `required_env` can reference either naming convention.
+- **Environment variables:** Use the `FOUNDRY_PROJECT_ENDPOINT` / `FOUNDRY_MODEL_DEPLOYMENT` names in `required_env` — the daily cadence provides these. (The older `AZURE_AI_PROJECT_ENDPOINT` / `MODEL_DEPLOYMENT` names are still provided too, for backward compatibility, but new samples should use the `FOUNDRY_` names.)
 
 ### Handling Hardcoded "Provide Your Own" Placeholders
 
@@ -53,12 +67,12 @@ variable, before running the command:
 live_service_validation:
   command: "python quickstart-create-agent.py"
   required_env:
-    - AZURE_AI_PROJECT_ENDPOINT
+    - FOUNDRY_PROJECT_ENDPOINT
   substitutions:
     - file: quickstart-create-agent.py
       replacements:
         - placeholder: "your_project_endpoint"
-          env: AZURE_AI_PROJECT_ENDPOINT
+          env: FOUNDRY_PROJECT_ENDPOINT
 ```
 
 - `file` must be a path inside the sample directory to a regular, non-symlinked text file.

--- a/CREATE_SAMPLE.md
+++ b/CREATE_SAMPLE.md
@@ -38,6 +38,37 @@ live_service_validation:
 ### How Full Runs Process This:
 - **Build Readiness:** Always runs build/compilation checks on PR touches and daily cadence.
 - **Live-Service Run:** Runs `live_service_validation.command` only if the `live_service_validation` section is present in `sample.yaml`.
+- **Environment variables:** The daily cadence provides both `AZURE_AI_PROJECT_ENDPOINT`/`MODEL_DEPLOYMENT` and the equivalent `FOUNDRY_PROJECT_ENDPOINT`/`FOUNDRY_MODEL_DEPLOYMENT` aliases, so `required_env` can reference either naming convention.
+
+### Handling Hardcoded "Provide Your Own" Placeholders
+
+Some quickstart samples intentionally keep copy/paste instructional placeholders in
+source (for example `"your_project_endpoint"`), so readers have an obvious spot to
+paste their own values. Live-service validation still needs the real value at
+runtime. Declare a `substitutions` list under `live_service_validation` to have the
+validator patch the placeholder in the workflow checkout, using an environment
+variable, before running the command:
+
+```yaml
+live_service_validation:
+  command: "python quickstart-create-agent.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+  substitutions:
+    - file: quickstart-create-agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT
+```
+
+- `file` must be a path inside the sample directory to a regular, non-symlinked text file.
+- Each `replacements` entry maps an exact-match `placeholder` string to an `env`
+  variable that must be non-empty.
+- The validator rejects the whole declaration as an infrastructure error (`2`) if a
+  target file is missing, outside the sample directory, malformed, or does not
+  contain the placeholder — nothing is partially rewritten.
+- Only the declared placeholder is replaced; other instructional strings (like an
+  agent name meant to stay sample-owned) are left untouched.
 
 ---
 

--- a/CREATE_SAMPLE.md
+++ b/CREATE_SAMPLE.md
@@ -1,0 +1,75 @@
+# Quick Guide: Creating and Validating Samples
+
+This guide provides the minimum steps to create a sample in this repository and configure its validation.
+
+---
+
+## Minimal Requirements for a Sample
+
+All samples live under `samples/<language>/<sample-folder>/` (supported languages: `csharp`, `java`, `javascript`, `python`, `typescript`, `go`).
+
+A sample is **defined and discovered** by the presence of a `sample.yaml` file in its root directory.
+
+---
+
+## Scenario A: Create a File/Sample Added to Full Runs (CI & Daily Cadence)
+
+To have your sample automatically discovered and validated in PR checks and the daily validation fleet:
+
+1. **Place your sample files** under `samples/<language>/<sample-name>/`.
+2. **Add a `sample.yaml` file** in the sample's root directory:
+
+```yaml
+name: Sample Name
+description: Brief description of what the sample demonstrates.
+
+# Optional: Custom build & compile overrides (language defaults used if omitted)
+build: "pip install -r requirements.txt"
+validate: "python -m py_compile *.py"
+
+# Optional: Opt-in to live-service execution during full runs
+live_service_validation:
+  command: "python main.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT
+```
+
+### How Full Runs Process This:
+- **Build Readiness:** Always runs build/compilation checks on PR touches and daily cadence.
+- **Live-Service Run:** Runs `live_service_validation.command` only if the `live_service_validation` section is present in `sample.yaml`.
+
+---
+
+## Scenario B: Create a File/Sample Validated Without Full Run
+
+To validate a sample without running live cloud services during full runs, or to run validation locally on demand:
+
+### Option 1: Build-Readiness Only (No Live Execution in CI)
+Include `sample.yaml` but **omit** the `live_service_validation` block.
+- The sample will be compiled/checked for build readiness in PRs and daily runs.
+- **No live service calls** will be executed during full runs.
+
+### Option 2: Local On-Demand Validation
+To test and validate locally before or without committing to full pipeline runs, use the local validation script:
+
+```bash
+# Validate build readiness locally
+bash .github/scripts/validate-sample.sh \
+  --language <language> \
+  --sample-dir samples/<language>/<sample-name>
+
+# Validate live-service execution locally
+SKIP_PROVISION=true bash .github/scripts/validate-sample.sh \
+  --mode live-service \
+  --sample-dir samples/<language>/<sample-name>
+```
+
+---
+
+## Reference Documentation
+For detailed contracts and workflow specifications:
+- [Per-Sample Validation Contract](.github/scripts/validate-sample.README.md)
+- [Daily Validation Cadence](.github/validation-pilot.README.md)
+- [Changed-Sample Detector](.github/scripts/detect-changed-samples.README.md)
+- [Contributing Guide](CONTRIBUTING.md)

--- a/CREATE_SAMPLE.md
+++ b/CREATE_SAMPLE.md
@@ -74,15 +74,25 @@ live_service_validation:
 
 ## Scenario B: Create a File/Sample Validated Without Full Run
 
-To validate a sample without running live cloud services during full runs, or to run validation locally on demand:
+Use this when you don't want (or aren't ready) to opt into automatic live-service
+runs in CI/daily cadence — either because you're still iterating, or because the
+sample should never call a live service in automation. `sample.yaml` is still
+recommended (and required for automation to discover the sample at all), but
+these options avoid triggering a live-service run in the shared pipeline.
 
 ### Option 1: Build-Readiness Only (No Live Execution in CI)
 Include `sample.yaml` but **omit** the `live_service_validation` block.
-- The sample will be compiled/checked for build readiness in PRs and daily runs.
-- **No live service calls** will be executed during full runs.
+- The sample is still discovered and compiled/checked for build readiness by PRs
+  and the daily cadence (that part of "full run" still happens automatically).
+- No live-service call is ever made by CI/daily cadence, because there's nothing
+  declared for it to run.
 
-### Option 2: Local On-Demand Validation
-To test and validate locally before or without committing to full pipeline runs, use the local validation script:
+### Option 2: Run Validation Yourself, On Demand
+Instead of waiting for CI or the daily cadence to pick up your sample, invoke the
+same validator script yourself, locally, whenever you want a quick check. This
+works whether or not the sample has a `sample.yaml` — without one, the script
+falls back to the language's default build/compile check; with one, it honors any
+declared `build`/`validate`/`test` commands or `live_service_validation` block.
 
 ```bash
 # Validate build readiness locally
@@ -90,11 +100,15 @@ bash .github/scripts/validate-sample.sh \
   --language <language> \
   --sample-dir samples/<language>/<sample-name>
 
-# Validate live-service execution locally
+# Validate live-service execution locally (only meaningful if
+# live_service_validation is declared in sample.yaml)
 SKIP_PROVISION=true bash .github/scripts/validate-sample.sh \
   --mode live-service \
   --sample-dir samples/<language>/<sample-name>
 ```
+
+This is just you running the script directly — it never registers the sample with
+CI or the daily cadence. Those still only pick up samples that have `sample.yaml`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Use the samples in this repository to try out Microsoft Foundry scenarios on you
 Pull requests run the required `trusted` check. Sample authors can run the same
 per-sample Build-readiness validator locally and can opt a sample into
 sample-owned Live-service validation through `sample.yaml`. See the
-[per-sample validation contract](.github/scripts/validate-sample.README.md) for
-commands and language behavior.
+[quick guide to creating and validating samples](CREATE_SAMPLE.md) for the
+minimum metadata and local commands, or the [per-sample validation
+contract](.github/scripts/validate-sample.README.md) for the complete commands,
+language behavior, substitutions, and available validation environment
+variables.
 
 The [daily public validation cadence](.github/validation-pilot.README.md)
 discovers metadata-bearing samples and publishes a run summary plus diagnostic


### PR DESCRIPTION
Adds a concise entry point for contributors who need to create a metadata-bearing sample and understand how it is validated.

The guide distinguishes build-readiness-only samples from samples that opt into live-service validation, provides the minimum `sample.yaml` shape and local validation commands, and links to the detailed validation contracts.