### PR TITLE
Add live validation placeholder substitution

### DIFF
--- a/.github/scripts/discover-validation-samples.py
+++ b/.github/scripts/discover-validation-samples.py
@@ -69,6 +69,7 @@ def live_service_declaration(root: Path, metadata: Path) -> tuple[bool, str]:
 
 
 def discover(root: Path) -> dict:
+    root = root.resolve()
     discovered = []
     paths_by_id = {}
     for metadata in sorted(root.glob("samples/**/sample.yaml")):

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -28,6 +28,89 @@ DISCOVERY_SPEC.loader.exec_module(validation_discovery)
 
 
 class ValidationPilotTests(unittest.TestCase):
+    def write_fake_yq(self, directory: Path) -> Path:
+        yq = directory / "yq"
+        yq.write_text(
+            """#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+if len(sys.argv) != 4 or sys.argv[1] != "eval":
+    raise SystemExit(2)
+
+query = sys.argv[2]
+document = yaml.safe_load(Path(sys.argv[3]).read_text(encoding="utf-8"))
+
+
+def resolve(path):
+    current = document
+    if path == ".":
+        return current
+    for part in path.lstrip(".").split("."):
+        if not part:
+            continue
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)(?:[[]([0-9]+)[]])?", part)
+        if not match:
+            raise SystemExit(2)
+        current = current[match.group(1)]
+        if match.group(2) is not None:
+            current = current[int(match.group(2))]
+    return current
+
+
+def print_value(value):
+    if isinstance(value, bool):
+        print("true" if value else "false")
+    elif value is None:
+        print("null")
+    elif isinstance(value, (dict, list)):
+        print(yaml.safe_dump(value), end="")
+    else:
+        print(value)
+
+
+if query == ".":
+    print_value(document)
+    raise SystemExit(0)
+
+root_has_match = re.fullmatch(r'has\\("([^"]+)"\\)', query)
+if root_has_match:
+    print("true" if isinstance(document, dict) and root_has_match.group(1) in document else "false")
+    raise SystemExit(0)
+
+has_match = re.fullmatch(r'(.+) \\| has\\("([^"]+)"\\)', query)
+if has_match:
+    value = resolve(has_match.group(1))
+    print("true" if isinstance(value, dict) and has_match.group(2) in value else "false")
+    raise SystemExit(0)
+
+kind_match = re.fullmatch(r"(.+) \\| kind", query)
+if kind_match:
+    value = resolve(kind_match.group(1))
+    print("map" if isinstance(value, dict) else "seq" if isinstance(value, list) else "scalar")
+    raise SystemExit(0)
+
+tag_match = re.fullmatch(r"(.+) \\| tag", query)
+if tag_match:
+    value = resolve(tag_match.group(1))
+    print("!!str" if isinstance(value, str) else "!!null" if value is None else "!!int")
+    raise SystemExit(0)
+
+length_match = re.fullmatch(r"(.+) \\| length", query)
+if length_match:
+    print(len(resolve(length_match.group(1))))
+    raise SystemExit(0)
+
+print_value(resolve(query))
+""",
+            encoding="utf-8",
+        )
+        yq.chmod(0o755)
+        return yq
+
     def test_workflow_calls_report_after_completeness(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("  report:", workflow)
@@ -171,6 +254,61 @@ class ValidationPilotTests(unittest.TestCase):
         )
         self.assertIn('SKIP_PROVISION: "true"', workflow)
         self.assertIn('python -m pip install -r "${{ matrix.path }}/requirements.txt"', workflow)
+
+    def test_live_service_substitutions_replace_instructional_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "substitution"
+            sample.mkdir(parents=True)
+            (sample / "quickstart.py").write_text(
+                'PROJECT_ENDPOINT = "your_project_endpoint"\n'
+                'AGENT_NAME = "your_agent_name"\n',
+                encoding="utf-8",
+            )
+            (sample / "check.py").write_text(
+                "from pathlib import Path\n"
+                "text = Path('quickstart.py').read_text(encoding='utf-8')\n"
+                "assert 'https://validation.example/api/projects/project' in text\n"
+                "assert 'your_agent_name' in text\n",
+                encoding="utf-8",
+            )
+            (sample / "sample.yaml").write_text(
+                "name: substitution\n"
+                "live_service_validation:\n"
+                "  command: \"python check.py\"\n"
+                "  substitutions:\n"
+                "    - file: quickstart.py\n"
+                "      replacements:\n"
+                "        - placeholder: \"your_project_endpoint\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "https://validation.example/api/projects/project",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("verdict=pass", completed.stdout)
+            quickstart = (sample / "quickstart.py").read_text(encoding="utf-8")
+            self.assertIn("https://validation.example/api/projects/project", quickstart)
+            self.assertIn("your_agent_name", quickstart)
 
     def test_discovery_jobs_install_pinned_dependencies(self) -> None:
         for workflow_path in (WORKFLOW, SELFTEST_WORKFLOW):

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -310,6 +310,112 @@ print_value(resolve(query))
             self.assertIn("https://validation.example/api/projects/project", quickstart)
             self.assertIn("your_agent_name", quickstart)
 
+    def test_live_service_substitutions_do_not_require_python(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "csharp" / "substitution"
+            sample.mkdir(parents=True)
+            (sample / "Program.cs").write_text(
+                'var endpoint = "your_project_endpoint";\n',
+                encoding="utf-8",
+            )
+            (sample / "sample.yaml").write_text(
+                "name: substitution\n"
+                "live_service_validation:\n"
+                "  command: \"grep -q 'https://validation.example/api/projects/project' Program.cs\"\n"
+                "  substitutions:\n"
+                "    - file: Program.cs\n"
+                "      replacements:\n"
+                "        - placeholder: \"your_project_endpoint\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            # A caller without a Python toolchain must still get substitutions.
+            broken_python = root / "python"
+            broken_python.write_text(
+                "#!/bin/sh\necho 'python must not be required' >&2\nexit 97\n",
+                encoding="utf-8",
+            )
+            broken_python.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "https://validation.example/api/projects/project",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("verdict=pass", completed.stdout)
+            self.assertNotIn("python must not be required", completed.stderr)
+            self.assertEqual(
+                (sample / "Program.cs").read_text(encoding="utf-8"),
+                'var endpoint = "https://validation.example/api/projects/project";\n',
+            )
+
+    def test_live_service_substitutions_leave_files_untouched_when_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "partial"
+            sample.mkdir(parents=True)
+            original = (
+                'PROJECT_ENDPOINT = "your_project_endpoint"\n'
+                'AGENT_NAME = "your_agent_name"\n'
+            )
+            (sample / "quickstart.py").write_text(original, encoding="utf-8")
+            (sample / "sample.yaml").write_text(
+                "name: partial\n"
+                "live_service_validation:\n"
+                "  command: \"true\"\n"
+                "  substitutions:\n"
+                "    - file: quickstart.py\n"
+                "      replacements:\n"
+                "        - placeholder: \"your_project_endpoint\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n"
+                "        - placeholder: \"missing_placeholder\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "https://validation.example/api/projects/project",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 2, completed.stdout)
+            self.assertIn("verdict=error", completed.stdout)
+            self.assertEqual(
+                (sample / "quickstart.py").read_text(encoding="utf-8"), original
+            )
+
     def test_discovery_jobs_install_pinned_dependencies(self) -> None:
         for workflow_path in (WORKFLOW, SELFTEST_WORKFLOW):
             workflow = workflow_path.read_text(encoding="utf-8")

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -416,6 +416,49 @@ print_value(resolve(query))
                 (sample / "quickstart.py").read_text(encoding="utf-8"), original
             )
 
+    def test_live_service_substitutions_reject_binary_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "binary"
+            sample.mkdir(parents=True)
+            original = b'your_project_endpoint\x00binary\n'
+            (sample / "payload.bin").write_bytes(original)
+            (sample / "sample.yaml").write_text(
+                "name: binary\n"
+                "live_service_validation:\n"
+                "  command: \"true\"\n"
+                "  substitutions:\n"
+                "    - file: payload.bin\n"
+                "      replacements:\n"
+                "        - placeholder: \"your_project_endpoint\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "https://validation.example/api/projects/project",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 2, completed.stdout)
+            self.assertIn("NUL-free text file", completed.stderr)
+            self.assertEqual((sample / "payload.bin").read_bytes(), original)
+
     def test_discovery_jobs_install_pinned_dependencies(self) -> None:
         for workflow_path in (WORKFLOW, SELFTEST_WORKFLOW):
             workflow = workflow_path.read_text(encoding="utf-8")

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -366,6 +366,97 @@ print_value(resolve(query))
                 'var endpoint = "https://validation.example/api/projects/project";\n',
             )
 
+    def test_live_service_substitutions_reject_trailing_parent_directory_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "parent"
+            (sample / "subdir").mkdir(parents=True)
+            (sample / "sample.yaml").write_text(
+                "name: parent\n"
+                "live_service_validation:\n"
+                "  command: \"true\"\n"
+                "  substitutions:\n"
+                "    - file: subdir/..\n"
+                "      replacements:\n"
+                "        - placeholder: \"your_project_endpoint\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "https://validation.example/api/projects/project",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 2, completed.stdout)
+            self.assertIn("must stay inside the sample directory: subdir/..", completed.stderr)
+
+    def test_live_service_substitutions_treat_glob_placeholders_literally(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "literal"
+            sample.mkdir(parents=True)
+            (sample / "config.txt").write_text(
+                "value=token*?[value]\n"
+                "other=tokenXYZvalue\n"
+                "again=token*?[value]\n",
+                encoding="utf-8",
+            )
+            (sample / "sample.yaml").write_text(
+                "name: literal\n"
+                "live_service_validation:\n"
+                "  command: \"grep -Fq 'literal replacement' config.txt && grep -Fq 'tokenXYZvalue' config.txt\"\n"
+                "  substitutions:\n"
+                "    - file: config.txt\n"
+                "      replacements:\n"
+                "        - placeholder: \"token*?[value]\"\n"
+                "          env: AZURE_AI_PROJECT_ENDPOINT\n",
+                encoding="utf-8",
+            )
+            self.write_fake_yq(root)
+            env = {
+                **os.environ,
+                "PATH": f"{root}{os.pathsep}{Path(sys.executable).parent}{os.pathsep}{os.environ['PATH']}",
+                "SKIP_PROVISION": "true",
+                "AZURE_AI_PROJECT_ENDPOINT": "literal replacement",
+            }
+            completed = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "validate-sample.sh"),
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    str(sample),
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                (sample / "config.txt").read_text(encoding="utf-8"),
+                "value=literal replacement\n"
+                "other=tokenXYZvalue\n"
+                "again=literal replacement\n",
+            )
+
     def test_live_service_substitutions_leave_files_untouched_when_invalid(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -67,6 +67,11 @@ live_service_validation:
   required_env:
     - AZURE_OPENAI_ENDPOINT
     - MODEL_DEPLOYMENT
+  substitutions:
+    - file: run_sample.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT
 ```
 
 The contract is:
@@ -90,6 +95,15 @@ The contract is:
 - `live_service_validation.required_env` is optional. When present, it must be a list of valid
   environment-variable names. Every listed variable must be non-empty or the
   validator returns infrastructure error (`2`) before executing sample code.
+- `live_service_validation.substitutions` is optional. Use it when source files
+  intentionally contain copy/paste instructional placeholders, such as
+  `"your_project_endpoint"`, but the validation caller owns the real value. Each
+  substitution names a file inside the sample directory and one or more
+  `placeholder` to `env` replacements. The validator requires each environment
+  variable to be non-empty, replaces every exact placeholder occurrence in the
+  workflow checkout before running the live-service command, and returns
+  infrastructure error (`2`) if the target file is outside the sample directory,
+  missing, malformed, or does not contain the placeholder.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
   or `false` whenever live-service validation is declared. The validator
   passes it through but never provisions resources itself. Current repository
@@ -110,8 +124,8 @@ The contract is:
 
 The validator rejects the legacy `l4` key with a migration message. It also rejects
 a scalar `live_service_validation`, a missing/non-string/empty `command`, a non-list
-`required_env`, invalid variable names, malformed YAML, and missing declared
-environment inputs as infrastructure errors.
+`required_env`, invalid variable names, malformed YAML, invalid substitution
+declarations, and missing declared environment inputs as infrastructure errors.
 
 ## Caller responsibilities
 

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -103,7 +103,11 @@ The contract is:
   variable to be non-empty, replaces every exact placeholder occurrence in the
   workflow checkout before running the live-service command, and returns
   infrastructure error (`2`) if the target file is outside the sample directory,
-  missing, malformed, or does not contain the placeholder.
+  missing, malformed, or does not contain the placeholder. Substitutions are
+  validated and applied in memory first and written only after the whole
+  declaration is valid, so a rejected declaration never leaves a partially
+  rewritten checkout. Rewriting uses Bash only, so a substitution never adds a
+  toolchain requirement beyond the sample's own language.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
   or `false` whenever live-service validation is declared. The validator
   passes it through but never provisions resources itself. Current repository

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -106,7 +106,8 @@ The contract is:
   missing, malformed, or does not contain the placeholder. Substitutions are
   validated and applied in memory first and written only after the whole
   declaration is valid, so a rejected declaration never leaves a partially
-  rewritten checkout. Rewriting uses Bash only, so a substitution never adds a
+  rewritten checkout. Target files must be regular, non-symlinked text files
+  without NUL bytes. Rewriting uses Bash only, so a substitution never adds a
   toolchain requirement beyond the sample's own language.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
   or `false` whenever live-service validation is declared. The validator

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -381,6 +381,22 @@ cleanup_python_venv() {
 # The caller owns authentication and configuration. This script never provisions, logs in,
 # or invents defaults: it inherits the caller environment and requires the caller to set
 # SKIP_PROVISION to exactly true or false. A missing declaration is a successful no-op.
+escape_bash_pattern_literal() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\*/\\*}"
+    value="${value//\?/\\?}"
+    value="${value//\[/\\[}"
+    value="${value//\]/\\]}"
+    value="${value//\(/\\(}"
+    value="${value//\)/\\)}"
+    value="${value//@/\\@}"
+    value="${value//\!/\\!}"
+    value="${value//+/\\+}"
+    value="${value//|/\\|}"
+    printf '%s' "$value"
+}
+
 apply_live_service_substitutions() {
     local yaml="$SAMPLE_DIR/sample.yaml"
     if [ "$(yq eval '.live_service_validation | has("substitutions")' "$yaml" 2>/dev/null)" != "true" ]; then
@@ -423,7 +439,7 @@ apply_live_service_substitutions() {
         printf '%s' "$file" | grep -q '[^[:space:]]' ||
             error "sample.yaml live_service_validation.substitutions[$i].file must be a non-empty string"
         case "$file" in
-            /*|*../*|../*|*"/.."|".") error "sample.yaml live_service_validation.substitutions[$i].file must stay inside the sample directory: $file" ;;
+            /*|*../*|../*|*/..|..|".") error "sample.yaml live_service_validation.substitutions[$i].file must stay inside the sample directory: $file" ;;
         esac
         [ -f "$SAMPLE_DIR/$file" ] ||
             error "sample.yaml live_service_validation.substitutions[$i].file does not exist or is not a regular file: $file"
@@ -472,7 +488,7 @@ apply_live_service_substitutions() {
             pending_count=$((pending_count + 1))
         fi
 
-        local j replacement_kind placeholder_tag placeholder env_tag env_name env_value
+        local j replacement_kind placeholder_tag placeholder placeholder_pattern env_tag env_name env_value
         j=0
         while [ "$j" -lt "$replacement_count" ]; do
             replacement_kind="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j] | kind" "$yaml" 2>/dev/null)" ||
@@ -487,6 +503,7 @@ apply_live_service_substitutions() {
                 error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder: $yaml"
             printf '%s' "$placeholder" | grep -q '[^[:space:]]' ||
                 error "sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder must be a non-empty string"
+            placeholder_pattern="$(escape_bash_pattern_literal "$placeholder")"
 
             env_tag="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j].env | tag" "$yaml" 2>/dev/null)" ||
                 error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].env: $yaml"
@@ -501,10 +518,17 @@ apply_live_service_substitutions() {
             env_value="${!env_name}"
 
             case "${pending_contents[$slot]}" in
-                *"$placeholder"*) ;;
+                *$placeholder_pattern*) ;;
                 *) error "live-service substitution placeholder not found in $file: $placeholder" ;;
             esac
-            pending_contents[$slot]="${pending_contents[$slot]//"$placeholder"/$env_value}"
+            local updated_content="" remaining_content="${pending_contents[$slot]}" prefix
+            while case "$remaining_content" in *$placeholder_pattern*) true ;; *) false ;; esac; do
+                prefix="${remaining_content%%$placeholder_pattern*}"
+                updated_content+="$prefix$env_value"
+                remaining_content="${remaining_content#"$prefix"}"
+                remaining_content="${remaining_content#"$placeholder"}"
+            done
+            pending_contents[$slot]="$updated_content$remaining_content"
             j=$((j + 1))
         done
         i=$((i + 1))

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -401,8 +401,11 @@ apply_live_service_substitutions() {
 
     # Preflight: every replacement is validated and applied in memory first, so a
     # later invalid replacement can never leave the checkout partially rewritten.
+    # Parallel indexed arrays (not an associative array) keep this loop working on
+    # Bash 3.2, which is still the default shell on macOS.
     local -a pending_paths=()
-    local -A pending_content=()
+    local -a pending_contents=()
+    local slot pending_index
 
     i=0
     while [ "$i" -lt "$substitutions_count" ]; do
@@ -445,11 +448,23 @@ apply_live_service_substitutions() {
         [ "$replacement_count" -gt 0 ] ||
             error "sample.yaml live_service_validation.substitutions[$i].replacements must not be empty"
 
-        if [ -z "${pending_content[$target_file]+set}" ]; then
+        slot=""
+        pending_index=0
+        while [ "$pending_index" -lt "${#pending_paths[@]}" ]; do
+            if [ "${pending_paths[$pending_index]}" = "$target_file" ]; then
+                slot="$pending_index"
+                break
+            fi
+            pending_index=$((pending_index + 1))
+        done
+        if [ -z "$slot" ]; then
             local content=""
-            IFS= read -r -d '' content <"$target_file"
-            pending_content["$target_file"]="$content"
+            # read exits non-zero at EOF without a NUL delimiter, which is the normal
+            # case for a text file; the whole file is still captured in "$content".
+            IFS= read -r -d '' content <"$target_file" || true
+            slot="${#pending_paths[@]}"
             pending_paths+=("$target_file")
+            pending_contents+=("$content")
         fi
 
         local j replacement_kind placeholder_tag placeholder env_tag env_name env_value
@@ -480,21 +495,22 @@ apply_live_service_substitutions() {
                 error "required live-service substitution environment variable is missing or empty: $env_name"
             env_value="${!env_name}"
 
-            case "${pending_content[$target_file]}" in
+            case "${pending_contents[$slot]}" in
                 *"$placeholder"*) ;;
                 *) error "live-service substitution placeholder not found in $file: $placeholder" ;;
             esac
-            pending_content["$target_file"]="${pending_content[$target_file]//"$placeholder"/$env_value}"
+            pending_contents[$slot]="${pending_contents[$slot]//"$placeholder"/$env_value}"
             j=$((j + 1))
         done
         i=$((i + 1))
     done
 
     # Commit: the whole declaration validated, so every rewrite can now be written.
-    local path
-    for path in ${pending_paths[@]+"${pending_paths[@]}"}; do
-        printf '%s' "${pending_content[$path]}" >"$path" ||
-            error "live-service substitution failed to write file: $path"
+    pending_index=0
+    while [ "$pending_index" -lt "${#pending_paths[@]}" ]; do
+        printf '%s' "${pending_contents[$pending_index]}" >"${pending_paths[$pending_index]}" ||
+            error "live-service substitution failed to write file: ${pending_paths[$pending_index]}"
+        pending_index=$((pending_index + 1))
     done
 }
 

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -405,7 +405,7 @@ apply_live_service_substitutions() {
     # Bash 3.2, which is still the default shell on macOS.
     local -a pending_paths=()
     local -a pending_contents=()
-    local slot pending_index
+    local slot pending_index pending_count=0
 
     i=0
     while [ "$i" -lt "$substitutions_count" ]; do
@@ -450,7 +450,7 @@ apply_live_service_substitutions() {
 
         slot=""
         pending_index=0
-        while [ "$pending_index" -lt "${#pending_paths[@]}" ]; do
+        while [ "$pending_index" -lt "$pending_count" ]; do
             if [ "${pending_paths[$pending_index]}" = "$target_file" ]; then
                 slot="$pending_index"
                 break
@@ -459,12 +459,17 @@ apply_live_service_substitutions() {
         done
         if [ -z "$slot" ]; then
             local content=""
+            # Shell strings cannot carry NUL bytes, so a binary file is rejected rather
+            # than silently truncated at its first NUL when the rewrite is written back.
+            tr -d '\000' <"$target_file" | cmp -s - "$target_file" ||
+                error "sample.yaml live_service_validation.substitutions[$i].file is not a NUL-free text file: $file"
             # read exits non-zero at EOF without a NUL delimiter, which is the normal
             # case for a text file; the whole file is still captured in "$content".
             IFS= read -r -d '' content <"$target_file" || true
-            slot="${#pending_paths[@]}"
+            slot="$pending_count"
             pending_paths+=("$target_file")
             pending_contents+=("$content")
+            pending_count=$((pending_count + 1))
         fi
 
         local j replacement_kind placeholder_tag placeholder env_tag env_name env_value
@@ -507,7 +512,7 @@ apply_live_service_substitutions() {
 
     # Commit: the whole declaration validated, so every rewrite can now be written.
     pending_index=0
-    while [ "$pending_index" -lt "${#pending_paths[@]}" ]; do
+    while [ "$pending_index" -lt "$pending_count" ]; do
         printf '%s' "${pending_contents[$pending_index]}" >"${pending_paths[$pending_index]}" ||
             error "live-service substitution failed to write file: ${pending_paths[$pending_index]}"
         pending_index=$((pending_index + 1))

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -388,12 +388,21 @@ apply_live_service_substitutions() {
     fi
 
     local substitutions_kind substitutions_count i substitution_kind file_tag file replacement_count replacements_kind
+    local resolved_sample_root resolved_dir target_file
     substitutions_kind="$(yq eval '.live_service_validation.substitutions | kind' "$yaml" 2>/dev/null)" ||
         error "failed to read sample.yaml live_service_validation.substitutions: $yaml"
     [ "$substitutions_kind" = "seq" ] ||
         error "sample.yaml live_service_validation.substitutions must be a list"
     substitutions_count="$(yq eval '.live_service_validation.substitutions | length' "$yaml" 2>/dev/null)" ||
         error "failed to read sample.yaml live_service_validation.substitutions: $yaml"
+
+    resolved_sample_root="$(cd "$SAMPLE_DIR" 2>/dev/null && pwd -P)" ||
+        error "failed to resolve sample directory: $SAMPLE_DIR"
+
+    # Preflight: every replacement is validated and applied in memory first, so a
+    # later invalid replacement can never leave the checkout partially rewritten.
+    local -a pending_paths=()
+    local -A pending_content=()
 
     i=0
     while [ "$i" -lt "$substitutions_count" ]; do
@@ -415,6 +424,17 @@ apply_live_service_substitutions() {
         esac
         [ -f "$SAMPLE_DIR/$file" ] ||
             error "sample.yaml live_service_validation.substitutions[$i].file does not exist or is not a regular file: $file"
+        [ ! -L "$SAMPLE_DIR/$file" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].file must not be a symlink: $file"
+        resolved_dir="$(cd "$(dirname "$SAMPLE_DIR/$file")" 2>/dev/null && pwd -P)" ||
+            error "sample.yaml live_service_validation.substitutions[$i].file resolves outside the sample directory: $file"
+        case "$resolved_dir" in
+            "$resolved_sample_root"|"$resolved_sample_root"/*) ;;
+            *) error "sample.yaml live_service_validation.substitutions[$i].file resolves outside the sample directory: $file" ;;
+        esac
+        target_file="$resolved_dir/$(basename "$file")"
+        [ -r "$target_file" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].file is not readable: $file"
 
         replacements_kind="$(yq eval ".live_service_validation.substitutions[$i].replacements | kind" "$yaml" 2>/dev/null)" ||
             error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements: $yaml"
@@ -425,7 +445,14 @@ apply_live_service_substitutions() {
         [ "$replacement_count" -gt 0 ] ||
             error "sample.yaml live_service_validation.substitutions[$i].replacements must not be empty"
 
-        local j replacement_kind placeholder_tag placeholder env_tag env_name env_value target_file substitution_rc
+        if [ -z "${pending_content[$target_file]+set}" ]; then
+            local content=""
+            IFS= read -r -d '' content <"$target_file"
+            pending_content["$target_file"]="$content"
+            pending_paths+=("$target_file")
+        fi
+
+        local j replacement_kind placeholder_tag placeholder env_tag env_name env_value
         j=0
         while [ "$j" -lt "$replacement_count" ]; do
             replacement_kind="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j] | kind" "$yaml" 2>/dev/null)" ||
@@ -452,36 +479,22 @@ apply_live_service_substitutions() {
             [ -n "${!env_name:-}" ] ||
                 error "required live-service substitution environment variable is missing or empty: $env_name"
             env_value="${!env_name}"
-            target_file="$SAMPLE_DIR/$file"
-            require_tool python
-            SAMPLE_ROOT="$SAMPLE_DIR" TARGET_FILE="$target_file" PLACEHOLDER="$placeholder" REPLACEMENT_VALUE="$env_value" python - <<'PY'
-import os
-from pathlib import Path
 
-sample_root = Path(os.environ["SAMPLE_ROOT"]).resolve()
-path = Path(os.environ["TARGET_FILE"])
-placeholder = os.environ["PLACEHOLDER"]
-replacement = os.environ["REPLACEMENT_VALUE"]
-resolved_path = path.resolve()
-try:
-    resolved_path.relative_to(sample_root)
-except ValueError:
-    raise SystemExit(4)
-text = resolved_path.read_text(encoding="utf-8")
-if placeholder not in text:
-    raise SystemExit(3)
-resolved_path.write_text(text.replace(placeholder, replacement), encoding="utf-8")
-PY
-            substitution_rc=$?
-            case "$substitution_rc" in
-                0) ;;
-                3) error "live-service substitution placeholder not found in $file: $placeholder" ;;
-                4) error "sample.yaml live_service_validation.substitutions[$i].file resolves outside the sample directory: $file" ;;
-                *) error "live-service substitution failed for $file" ;;
+            case "${pending_content[$target_file]}" in
+                *"$placeholder"*) ;;
+                *) error "live-service substitution placeholder not found in $file: $placeholder" ;;
             esac
+            pending_content["$target_file"]="${pending_content[$target_file]//"$placeholder"/$env_value}"
             j=$((j + 1))
         done
         i=$((i + 1))
+    done
+
+    # Commit: the whole declaration validated, so every rewrite can now be written.
+    local path
+    for path in ${pending_paths[@]+"${pending_paths[@]}"}; do
+        printf '%s' "${pending_content[$path]}" >"$path" ||
+            error "live-service substitution failed to write file: $path"
     done
 }
 

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -372,10 +372,119 @@ cleanup_python_venv() {
 #   live_service_validation:
 #     command: "<credentialed runtime assertion>"
 #     required_env: [OPTIONAL_ENV_NAME, ...]  # optional
+#     substitutions:                         # optional
+#       - file: "relative/sample-file.py"
+#         replacements:
+#           - placeholder: "your_project_endpoint"
+#             env: AZURE_AI_PROJECT_ENDPOINT
 #
 # The caller owns authentication and configuration. This script never provisions, logs in,
 # or invents defaults: it inherits the caller environment and requires the caller to set
 # SKIP_PROVISION to exactly true or false. A missing declaration is a successful no-op.
+apply_live_service_substitutions() {
+    local yaml="$SAMPLE_DIR/sample.yaml"
+    if [ "$(yq eval '.live_service_validation | has("substitutions")' "$yaml" 2>/dev/null)" != "true" ]; then
+        return 0
+    fi
+
+    local substitutions_kind substitutions_count i substitution_kind file_tag file replacement_count replacements_kind
+    substitutions_kind="$(yq eval '.live_service_validation.substitutions | kind' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.substitutions: $yaml"
+    [ "$substitutions_kind" = "seq" ] ||
+        error "sample.yaml live_service_validation.substitutions must be a list"
+    substitutions_count="$(yq eval '.live_service_validation.substitutions | length' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.substitutions: $yaml"
+
+    i=0
+    while [ "$i" -lt "$substitutions_count" ]; do
+        substitution_kind="$(yq eval ".live_service_validation.substitutions[$i] | kind" "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.substitutions[$i]: $yaml"
+        [ "$substitution_kind" = "map" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i] must be a mapping"
+
+        file_tag="$(yq eval ".live_service_validation.substitutions[$i].file | tag" "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.substitutions[$i].file: $yaml"
+        [ "$file_tag" = "!!str" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].file must be a non-empty string"
+        file="$(yq eval ".live_service_validation.substitutions[$i].file" "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.substitutions[$i].file: $yaml"
+        printf '%s' "$file" | grep -q '[^[:space:]]' ||
+            error "sample.yaml live_service_validation.substitutions[$i].file must be a non-empty string"
+        case "$file" in
+            /*|*../*|../*|*"/.."|".") error "sample.yaml live_service_validation.substitutions[$i].file must stay inside the sample directory: $file" ;;
+        esac
+        [ -f "$SAMPLE_DIR/$file" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].file does not exist or is not a regular file: $file"
+
+        replacements_kind="$(yq eval ".live_service_validation.substitutions[$i].replacements | kind" "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements: $yaml"
+        [ "$replacements_kind" = "seq" ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].replacements must be a list"
+        replacement_count="$(yq eval ".live_service_validation.substitutions[$i].replacements | length" "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements: $yaml"
+        [ "$replacement_count" -gt 0 ] ||
+            error "sample.yaml live_service_validation.substitutions[$i].replacements must not be empty"
+
+        local j replacement_kind placeholder_tag placeholder env_tag env_name env_value target_file substitution_rc
+        j=0
+        while [ "$j" -lt "$replacement_count" ]; do
+            replacement_kind="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j] | kind" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j]: $yaml"
+            [ "$replacement_kind" = "map" ] ||
+                error "sample.yaml live_service_validation.substitutions[$i].replacements[$j] must be a mapping"
+            placeholder_tag="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j].placeholder | tag" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder: $yaml"
+            [ "$placeholder_tag" = "!!str" ] ||
+                error "sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder must be a non-empty string"
+            placeholder="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j].placeholder" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder: $yaml"
+            printf '%s' "$placeholder" | grep -q '[^[:space:]]' ||
+                error "sample.yaml live_service_validation.substitutions[$i].replacements[$j].placeholder must be a non-empty string"
+
+            env_tag="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j].env | tag" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].env: $yaml"
+            [ "$env_tag" = "!!str" ] ||
+                error "sample.yaml live_service_validation.substitutions[$i].replacements[$j].env must be a string"
+            env_name="$(yq eval ".live_service_validation.substitutions[$i].replacements[$j].env" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.substitutions[$i].replacements[$j].env: $yaml"
+            [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] ||
+                error "sample.yaml live_service_validation.substitutions[$i].replacements[$j].env is not a valid environment-variable name: $env_name"
+            [ -n "${!env_name:-}" ] ||
+                error "required live-service substitution environment variable is missing or empty: $env_name"
+            env_value="${!env_name}"
+            target_file="$SAMPLE_DIR/$file"
+            require_tool python
+            SAMPLE_ROOT="$SAMPLE_DIR" TARGET_FILE="$target_file" PLACEHOLDER="$placeholder" REPLACEMENT_VALUE="$env_value" python - <<'PY'
+import os
+from pathlib import Path
+
+sample_root = Path(os.environ["SAMPLE_ROOT"]).resolve()
+path = Path(os.environ["TARGET_FILE"])
+placeholder = os.environ["PLACEHOLDER"]
+replacement = os.environ["REPLACEMENT_VALUE"]
+resolved_path = path.resolve()
+try:
+    resolved_path.relative_to(sample_root)
+except ValueError:
+    raise SystemExit(4)
+text = resolved_path.read_text(encoding="utf-8")
+if placeholder not in text:
+    raise SystemExit(3)
+resolved_path.write_text(text.replace(placeholder, replacement), encoding="utf-8")
+PY
+            substitution_rc=$?
+            case "$substitution_rc" in
+                0) ;;
+                3) error "live-service substitution placeholder not found in $file: $placeholder" ;;
+                4) error "sample.yaml live_service_validation.substitutions[$i].file resolves outside the sample directory: $file" ;;
+                *) error "live-service substitution failed for $file" ;;
+            esac
+            j=$((j + 1))
+        done
+        i=$((i + 1))
+    done
+}
+
 run_live_service_validation() {
     local yaml="$SAMPLE_DIR/sample.yaml"
     if [ ! -f "$yaml" ]; then
@@ -443,6 +552,8 @@ run_live_service_validation() {
         "") error "SKIP_PROVISION must be set by the live-service caller to true or false" ;;
         *) error "SKIP_PROVISION must be exactly true or false (got: $SKIP_PROVISION)" ;;
     esac
+
+    apply_live_service_substitutions
 
     echo "Running live-service command (SKIP_PROVISION=$SKIP_PROVISION): $cmd"
     local live_service_log

--- a/samples/csharp/quickstart/responses/sample.yaml
+++ b/samples/csharp/quickstart/responses/sample.yaml
@@ -1,3 +1,12 @@
 name: Quickstart Responses
 description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
+live_service_validation:
+  command: "dotnet run --no-build"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+  substitutions:
+    - file: quickstart-responses.cs
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT

--- a/samples/python/quickstart/chat-with-agent/sample.yaml
+++ b/samples/python/quickstart/chat-with-agent/sample.yaml
@@ -3,3 +3,12 @@ description: Basic quickstart sample demonstrating Microsoft Foundry chat with A
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
+live_service_validation:
+  command: "python quickstart-chat-with-agent.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+  substitutions:
+    - file: quickstart-chat-with-agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT

--- a/samples/python/quickstart/chat-with-agent/sample.yaml
+++ b/samples/python/quickstart/chat-with-agent/sample.yaml
@@ -3,12 +3,3 @@ description: Basic quickstart sample demonstrating Microsoft Foundry chat with A
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
-live_service_validation:
-  command: "python quickstart-chat-with-agent.py"
-  required_env:
-    - AZURE_AI_PROJECT_ENDPOINT
-  substitutions:
-    - file: quickstart-chat-with-agent.py
-      replacements:
-        - placeholder: "your_project_endpoint"
-          env: AZURE_AI_PROJECT_ENDPOINT

--- a/samples/python/quickstart/create-agent/sample.yaml
+++ b/samples/python/quickstart/create-agent/sample.yaml
@@ -3,3 +3,12 @@ description: Basic quickstart sample demonstrating Microsoft Foundry agent creat
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
+live_service_validation:
+  command: "python quickstart-create-agent.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+  substitutions:
+    - file: quickstart-create-agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT

--- a/samples/python/quickstart/responses/sample.yaml
+++ b/samples/python/quickstart/responses/sample.yaml
@@ -3,3 +3,12 @@ description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
+live_service_validation:
+  command: "python quickstart-responses.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+  substitutions:
+    - file: quickstart-responses.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: AZURE_AI_PROJECT_ENDPOINT


### PR DESCRIPTION
## Summary

Some quickstart samples intentionally keep copy/paste instructional placeholders in source files, but live-service validation needs the real environment-specific values at runtime. This adds a sample-owned substitution contract so validation can patch placeholders in the workflow checkout before running the declared live-service command.

## Changes

- Adds optional `live_service_validation.substitutions` support to the sample validator.
- Validates substitution shape, environment variables, file paths, and placeholder presence before writing changes.
- Opts `samples/python/quickstart/create-agent` into live-service validation by replacing only `your_project_endpoint` from `AZURE_AI_PROJECT_ENDPOINT`; the agent name remains a sample-owned string.
- Documents the new contract and covers it with a focused validation test.

## Validation

- `bash -n .github/scripts/validate-sample.sh`
- `python -m unittest discover -s .github/scripts/test -p 'test_validation_pilot.py'`
- `discover-validation-samples.py` confirms the chat-with-agent sample is in the live-service matrix