### PR TITLE
Add Foundry environment variable aliases to validation

### DIFF
--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -166,7 +166,15 @@ class ValidationPilotTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
+            "FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}",
+            workflow,
+        )
+        self.assertIn(
             "MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}",
+            workflow,
+        )
+        self.assertIn(
+            "FOUNDRY_MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}",
             workflow,
         )
         self.assertIn('SKIP_PROVISION: "true"', workflow)

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -122,7 +122,9 @@ jobs:
       # P4.1 never provisions. P4.2 owns any future cold-provisioning caller.
       SKIP_PROVISION: "true"
       AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
+      FOUNDRY_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
       MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}
+      FOUNDRY_MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
The validation workflow's `L4-validation` environment needs the current `FOUNDRY_` variable names in addition to the existing names so samples using either convention receive the same configuration.

This change adds:
- `FOUNDRY_PROJECT_ENDPOINT` mapped from `vars.AZURE_AI_PROJECT_ENDPOINT`
- `FOUNDRY_MODEL_DEPLOYMENT` mapped from `vars.MODEL_DEPLOYMENT`
- Structural test assertions for both aliases