### PR TITLE
Fix local authentication in .NET invocations sample

### DIFF
--- a/samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld/src/hello-world-dotnet-invocations/HelloWorld.csproj
+++ b/samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld/src/hello-world-dotnet-invocations/HelloWorld.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <!-- Invocations protocol SDK — provides InvocationsServer, InvocationHandler, InvocationContext -->
-    <PackageReference Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.5" />
+    <PackageReference Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.7" />
     <!-- Foundry SDK — provides AIProjectClient and ProjectOpenAIClient -->
     <PackageReference Include="Azure.AI.Projects" Version="2.0.1" />
     <!-- OpenAI bridge for Foundry — provides GetProjectResponsesClientForModel() via ProjectOpenAIClient -->


### PR DESCRIPTION
Closes #806

### Summary

This PR upgrades the .NET Hello World Invocations sample to `Azure.AI.AgentServer.Invocations` 1.0.0-beta.7. The previous beta.5 dependency resolved `Azure.Core` 1.59.0, which has a Windows regression where `DefaultAzureCredential` stops after an unavailable managed identity instead of continuing to local developer credentials.

The updated SDK resolves `Azure.Core` 1.62.0, which includes the credential-chain fix from Azure/azure-sdk-for-net#60701. This keeps managed identity authentication in Foundry while allowing local runs to use Azure CLI, Azure Developer CLI, Visual Studio, or other configured developer credentials.

### Testing

- Built the .NET 10 sample successfully with no warnings or errors.
- Confirmed NuGet resolves `Azure.AI.AgentServer.Core` 1.0.0-beta.29 and `Azure.Core` 1.62.0.