### PR TITLE
Fix quickstart live validation

### DIFF
--- a/samples/csharp/quickstart/responses/sample.yaml
+++ b/samples/csharp/quickstart/responses/sample.yaml
@@ -2,7 +2,7 @@ name: Quickstart Responses
 description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
 live_service_validation:
-  command: "dotnet run --no-build"
+  command: "dotnet run"
   required_env:
     - AZURE_AI_PROJECT_ENDPOINT
   substitutions:

--- a/samples/python/quickstart/create-agent/requirements.txt
+++ b/samples/python/quickstart/create-agent/requirements.txt
@@ -1,4 +1,5 @@
 azure-ai-projects==2.3.0
 azure-identity
+httpx
 python-dotenv
 openai

--- a/samples/python/quickstart/responses/requirements.txt
+++ b/samples/python/quickstart/responses/requirements.txt
@@ -1,4 +1,5 @@
 azure-ai-projects==2.3.0
 azure-identity
+httpx
 python-dotenv
 openai


### PR DESCRIPTION
The live-service validation dashboard identified two Python quickstarts that omit a runtime dependency and a C# quickstart that runs a stale pre-substitution build.

Add `httpx` as an explicit dependency for the Python create-agent and responses quickstarts. Run the C# responses quickstart without `--no-build` so the endpoint substituted by validation is compiled before execution.