### PR TITLE
Add live-cleanup convention and standalone agent creation to quickstarts

### DIFF
--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -621,6 +621,24 @@ run_live_service_validation() {
     live_service_rc=$?
     cat "$live_service_log"
     rm -f "$live_service_log"
+
+    # Best-effort, convention-based per-sample cleanup: if the sample directory ships
+    # a live-cleanup.sh, run it automatically here — no sample.yaml declaration needed.
+    # This only ever deletes what that sample's own live_service_validation.command
+    # created (e.g. a named agent); it never touches shared/pre-existing project
+    # resources such as the model deployment. Its own exit status is logged but never
+    # changes the pass/fail verdict below, which is always driven by $live_service_rc.
+    if [ -f "$SAMPLE_DIR/live-cleanup.sh" ]; then
+        echo "Running live-cleanup.sh (best-effort; does not affect pass/fail)"
+        local cleanup_log cleanup_rc
+        cleanup_log="$(mktemp)" || error "failed to create temporary live-cleanup log"
+        ( cd "$SAMPLE_DIR" && bash live-cleanup.sh ) >"$cleanup_log" 2>&1
+        cleanup_rc=$?
+        cat "$cleanup_log"
+        rm -f "$cleanup_log"
+        [ "$cleanup_rc" -eq 0 ] || echo "WARNING: live-cleanup.sh exited $cleanup_rc (ignored)"
+    fi
+
     case "$live_service_rc" in
         0) pass ;;
         1) fail "sample.yaml live_service_validation.command reported sample failure (exit 1)" ;;

--- a/samples/csharp/quickstart/chat-with-agent/live-cleanup.sh
+++ b/samples/csharp/quickstart/chat-with-agent/live-cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+dotnet restore live-cleanup --source https://api.nuget.org/v3/index.json
+dotnet run --project live-cleanup --no-restore

--- a/samples/csharp/quickstart/chat-with-agent/live-cleanup/live-cleanup.csproj
+++ b/samples/csharp/quickstart/chat-with-agent/live-cleanup/live-cleanup.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Azure.AI.Projects" Version="2.0.0" />
         <PackageReference Include="Azure.AI.Projects.Agents" Version="2.0.0" />
-        <PackageReference Include="Azure.AI.Extensions.OpenAI" Version="2.0.0" />
         <PackageReference Include="Azure.Identity" Version="1.20.0" />
     </ItemGroup>
 </Project>

--- a/samples/csharp/quickstart/chat-with-agent/live-cleanup/live-setup-delete-agent.cs
+++ b/samples/csharp/quickstart/chat-with-agent/live-cleanup/live-setup-delete-agent.cs
@@ -1,0 +1,18 @@
+// Live-validation-only helper: deletes the agent created by quickstart-chat-with-agent.cs
+// so repeated live-validation runs don't accumulate agent versions. Not part of the
+// documented quickstart narrative.
+using Azure.Identity;
+using Azure.AI.Projects;
+using Azure.AI.Projects.Agents;
+
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+var foundryProjectEndpoint = "your_project_endpoint";
+var foundryAgentName = "your-agent-name";
+
+// Create project client to call Foundry API
+AIProjectClient projectClient = new(
+    endpoint: new Uri(foundryProjectEndpoint),
+    tokenProvider: new DefaultAzureCredential());
+
+projectClient.AgentAdministrationClient.DeleteAgent(foundryAgentName);
+Console.WriteLine($"Agent deleted (name: {foundryAgentName})");

--- a/samples/csharp/quickstart/chat-with-agent/live-cleanup/nuget.config
+++ b/samples/csharp/quickstart/chat-with-agent/live-cleanup/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
+++ b/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
@@ -1,5 +1,6 @@
 using Azure.Identity;
 using Azure.AI.Projects;
+using Azure.AI.Projects.Agents;
 using Azure.AI.Extensions.OpenAI;
 using OpenAI.Responses;
 
@@ -7,12 +8,21 @@ using OpenAI.Responses;
 
 // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 var foundryProjectEndpoint = "your_project_endpoint";
-var foundryAgentName = "your_agent_name";
+var foundryAgentName = "your-agent-name";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(
     endpoint: new Uri(foundryProjectEndpoint),
     tokenProvider: new DefaultAzureCredential());
+
+// Create the agent (or a new version, if it already exists)
+ProjectsAgentDefinition agentDefinition = new DeclarativeAgentDefinition("gpt-5-mini") // supports all Foundry direct models
+{
+    Instructions = "You are a helpful assistant that answers general questions",
+};
+projectClient.AgentAdministrationClient.CreateAgentVersion(
+    foundryAgentName,
+    options: new(agentDefinition));
 
 // Create a conversation for multi-turn chat
 ProjectConversation conversation = projectClient.ProjectOpenAIClient.GetProjectConversationsClient().CreateProjectConversation();

--- a/samples/csharp/quickstart/chat-with-agent/sample.yaml
+++ b/samples/csharp/quickstart/chat-with-agent/sample.yaml
@@ -1,3 +1,20 @@
 name: Quickstart Chat with Agent
 description: Basic quickstart sample demonstrating Microsoft Foundry chat with Agent.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) restores/runs the live-cleanup/
+  # helper project, deleting the agent quickstart-chat-with-agent.cs creates, so a
+  # live run doesn't leave an agent behind. It runs automatically after the command
+  # below; no chaining needed here.
+  command: "dotnet run"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+  substitutions:
+    - file: live-cleanup/live-setup-delete-agent.cs
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+    - file: quickstart-chat-with-agent.cs
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/csharp/quickstart/create-agent/live-cleanup.sh
+++ b/samples/csharp/quickstart/create-agent/live-cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+dotnet restore live-cleanup --source https://api.nuget.org/v3/index.json
+dotnet run --project live-cleanup --no-restore

--- a/samples/csharp/quickstart/create-agent/live-cleanup/live-cleanup.csproj
+++ b/samples/csharp/quickstart/create-agent/live-cleanup/live-cleanup.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Azure.AI.Projects" Version="2.0.0" />
         <PackageReference Include="Azure.AI.Projects.Agents" Version="2.0.0" />
-        <PackageReference Include="Azure.AI.Extensions.OpenAI" Version="2.0.0" />
         <PackageReference Include="Azure.Identity" Version="1.20.0" />
     </ItemGroup>
 </Project>

--- a/samples/csharp/quickstart/create-agent/live-cleanup/live-setup-delete-agent.cs
+++ b/samples/csharp/quickstart/create-agent/live-cleanup/live-setup-delete-agent.cs
@@ -1,0 +1,18 @@
+// Live-validation-only helper: deletes the agent created by quickstart-create-agent.cs
+// so repeated live-validation runs don't accumulate agent versions. Not part of the
+// documented quickstart narrative.
+using Azure.Identity;
+using Azure.AI.Projects;
+using Azure.AI.Projects.Agents;
+
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+var foundryProjectEndpoint = "your_project_endpoint";
+var foundryAgentName = "your-agent-name";
+
+// Create project client to call Foundry API
+AIProjectClient projectClient = new(
+    endpoint: new Uri(foundryProjectEndpoint),
+    tokenProvider: new DefaultAzureCredential());
+
+projectClient.AgentAdministrationClient.DeleteAgent(foundryAgentName);
+Console.WriteLine($"Agent deleted (name: {foundryAgentName})");

--- a/samples/csharp/quickstart/create-agent/live-cleanup/nuget.config
+++ b/samples/csharp/quickstart/create-agent/live-cleanup/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
+++ b/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
@@ -5,7 +5,7 @@ using Azure.AI.Extensions.OpenAI;
 
 // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 var foundryProjectEndpoint = "your_project_endpoint";
-var foundryAgentName = "your_agent_name";
+var foundryAgentName = "your-agent-name";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(

--- a/samples/csharp/quickstart/create-agent/sample.yaml
+++ b/samples/csharp/quickstart/create-agent/sample.yaml
@@ -1,3 +1,23 @@
 name: Quickstart Create Agent
 description: Basic quickstart sample demonstrating Microsoft Foundry agent creation.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) restores/runs the live-cleanup/
+  # helper project, deleting the agent quickstart-create-agent.cs creates, so a live
+  # run doesn't leave an agent behind. It runs automatically after the command below;
+  # no chaining needed here.
+  command: "dotnet run"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT
+  substitutions:
+    - file: quickstart-create-agent.cs
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+        - placeholder: "gpt-5-mini"
+          env: MODEL_DEPLOYMENT
+    - file: live-cleanup/live-setup-delete-agent.cs
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/java/quickstart/chat-with-agent/live-cleanup.sh
+++ b/samples/java/quickstart/chat-with-agent/live-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+mvn compile exec:java -Dexec.mainClass=com.azure.ai.agents.LiveSetupDeleteAgent

--- a/samples/java/quickstart/chat-with-agent/sample.yaml
+++ b/samples/java/quickstart/chat-with-agent/sample.yaml
@@ -3,3 +3,19 @@ description: Basic quickstart sample demonstrating Microsoft Foundry chat with A
 
 build: "mvn compile"
 validate: "mvn compile"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) deletes the agent
+  # ChatWithAgent.java creates, so a live run doesn't leave an agent behind. It runs
+  # automatically after the command below; no chaining needed here.
+  command: "mvn compile exec:java -Dexec.mainClass=com.azure.ai.agents.ChatWithAgent"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+  substitutions:
+    - file: src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+    - file: src/main/java/com/azure/ai/agents/ChatWithAgent.java
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
+++ b/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
@@ -1,5 +1,6 @@
 package com.azure.ai.agents;
 
+import com.azure.ai.agents.models.PromptAgentDefinition;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.openai.client.OpenAIClient;
 import com.openai.models.conversations.Conversation;
@@ -10,11 +11,17 @@ public class ChatWithAgent {
     public static void main(String[] args) {
         // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
         String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryAgentName = "your_agent_name";
+        String foundryAgentName = "your-agent-name";
         
         AgentsClientBuilder builder = new AgentsClientBuilder()
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .endpoint(foundryProjectEndpoint);
+
+        // Create the agent (or a new version, if it already exists)
+        AgentsClient agentsClient = builder.buildAgentsClient();
+        PromptAgentDefinition agentDefinition = new PromptAgentDefinition("gpt-5-mini") // supports all Foundry direct models
+                .setInstructions("You are a helpful assistant that answers general questions");
+        agentsClient.createAgentVersion(foundryAgentName, agentDefinition);
 
         // Create an OpenAI client bound to the agent endpoint
         OpenAIClient openai = builder.buildAgentScopedOpenAIClient(foundryAgentName);

--- a/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
+++ b/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
@@ -1,0 +1,24 @@
+package com.azure.ai.agents;
+
+// Live-validation-only helper: deletes the agent created by ChatWithAgent.java so
+// repeated live-validation runs don't accumulate agent versions. Not part of the
+// documented quickstart narrative.
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class LiveSetupDeleteAgent {
+    public static void main(String[] args) {
+        // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+        String foundryProjectEndpoint = "your_project_endpoint";
+        String foundryAgentName = "your-agent-name";
+
+        // Create agents client to call Foundry API
+        AgentsClient agentsClient = new AgentsClientBuilder()
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .endpoint(foundryProjectEndpoint)
+                .buildAgentsClient();
+
+        agentsClient.deleteAgent(foundryAgentName);
+        System.out.println("Agent deleted (name: " + foundryAgentName + ")");
+    }
+}

--- a/samples/java/quickstart/create-agent/live-cleanup.sh
+++ b/samples/java/quickstart/create-agent/live-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+mvn compile exec:java -Dexec.mainClass=com.azure.ai.agents.LiveSetupDeleteAgent

--- a/samples/java/quickstart/create-agent/sample.yaml
+++ b/samples/java/quickstart/create-agent/sample.yaml
@@ -3,3 +3,22 @@ description: Basic quickstart sample demonstrating Microsoft Foundry agent creat
 
 build: "mvn compile"
 validate: "mvn compile"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) deletes the agent
+  # CreateAgent.java creates, so a live run doesn't leave an agent behind. It runs
+  # automatically after the command below; no chaining needed here.
+  command: "mvn compile exec:java -Dexec.mainClass=com.azure.ai.agents.CreateAgent"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT
+  substitutions:
+    - file: src/main/java/com/azure/ai/agents/CreateAgent.java
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+        - placeholder: "gpt-5-mini"
+          env: MODEL_DEPLOYMENT
+    - file: src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
+++ b/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
@@ -8,7 +8,7 @@ public class CreateAgent {
     public static void main(String[] args) {
         // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
         String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryAgentName = "your_agent_name";
+        String foundryAgentName = "your-agent-name";
 
         // Create agents client to call Foundry API
         AgentsClient agentsClient = new AgentsClientBuilder()

--- a/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
+++ b/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/LiveSetupDeleteAgent.java
@@ -1,0 +1,24 @@
+package com.azure.ai.agents;
+
+// Live-validation-only helper: deletes the agent created by CreateAgent.java so
+// repeated live-validation runs don't accumulate agent versions. Not part of the
+// documented quickstart narrative.
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class LiveSetupDeleteAgent {
+    public static void main(String[] args) {
+        // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+        String foundryProjectEndpoint = "your_project_endpoint";
+        String foundryAgentName = "your-agent-name";
+
+        // Create agents client to call Foundry API
+        AgentsClient agentsClient = new AgentsClientBuilder()
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .endpoint(foundryProjectEndpoint)
+                .buildAgentsClient();
+
+        agentsClient.deleteAgent(foundryAgentName);
+        System.out.println("Agent deleted (name: " + foundryAgentName + ")");
+    }
+}

--- a/samples/java/quickstart/responses/sample.yaml
+++ b/samples/java/quickstart/responses/sample.yaml
@@ -3,3 +3,15 @@ description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 
 build: "mvn compile"
 validate: "mvn compile"
+live_service_validation:
+  command: "mvn compile exec:java -Dexec.mainClass=com.azure.ai.agents.CreateResponse"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT
+  substitutions:
+    - file: src/main/java/com/azure/ai/agents/CreateResponse.java
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+        - placeholder: "gpt-5-mini"
+          env: MODEL_DEPLOYMENT

--- a/samples/python/quickstart/chat-with-agent/live-cleanup.sh
+++ b/samples/python/quickstart/chat-with-agent/live-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+python live_setup_delete_agent.py

--- a/samples/python/quickstart/chat-with-agent/live_setup_delete_agent.py
+++ b/samples/python/quickstart/chat-with-agent/live_setup_delete_agent.py
@@ -1,0 +1,15 @@
+# Live-validation-only helper: deletes the agent created for live validation so
+# repeated runs don't accumulate agents. Not part of the documented quickstart.
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+# Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
+FOUNDRY_AGENT_NAME = "your-agent-name"
+
+project = AIProjectClient(
+    endpoint=FOUNDRY_PROJECT_ENDPOINT,
+    credential=DefaultAzureCredential(),
+)
+project.agents.delete(FOUNDRY_AGENT_NAME)
+print(f"Agent deleted (name: {FOUNDRY_AGENT_NAME})")

--- a/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
+++ b/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
@@ -1,15 +1,26 @@
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import PromptAgentDefinition
 
 # Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
-FOUNDRY_AGENT_NAME = "your_agent_name"
+FOUNDRY_AGENT_NAME = "your-agent-name"
 
 # Create project and openai clients to call Foundry API
 project = AIProjectClient(
     endpoint=FOUNDRY_PROJECT_ENDPOINT,
     credential=DefaultAzureCredential(),
 )
+
+# Create the agent (or a new version, if it already exists)
+project.agents.create_version(
+    agent_name=FOUNDRY_AGENT_NAME,
+    definition=PromptAgentDefinition(
+        model="gpt-5-mini",
+        instructions="You are a helpful assistant that answers general questions",
+    ),
+)
+
 # Get an OpenAI client pre-bound to the specified agent
 openai = project.get_openai_client(agent_name=FOUNDRY_AGENT_NAME)
 

--- a/samples/python/quickstart/chat-with-agent/sample.yaml
+++ b/samples/python/quickstart/chat-with-agent/sample.yaml
@@ -3,3 +3,19 @@ description: Basic quickstart sample demonstrating Microsoft Foundry chat with A
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) deletes the agent
+  # quickstart-chat-with-agent.py creates, so a live run doesn't leave an agent
+  # behind. It runs automatically after the command below; no chaining needed here.
+  command: "python quickstart-chat-with-agent.py"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+  substitutions:
+    - file: live_setup_delete_agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+    - file: quickstart-chat-with-agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/python/quickstart/create-agent/live-cleanup.sh
+++ b/samples/python/quickstart/create-agent/live-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+python live_setup_delete_agent.py

--- a/samples/python/quickstart/create-agent/live_setup_delete_agent.py
+++ b/samples/python/quickstart/create-agent/live_setup_delete_agent.py
@@ -1,0 +1,16 @@
+# Live-validation-only helper: deletes the agent created by quickstart-create-agent.py
+# so repeated live-validation runs don't accumulate agents. Not part of the
+# documented quickstart narrative.
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+# Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
+FOUNDRY_AGENT_NAME = "your-agent-name"
+
+project = AIProjectClient(
+    endpoint=FOUNDRY_PROJECT_ENDPOINT,
+    credential=DefaultAzureCredential(),
+)
+project.agents.delete(FOUNDRY_AGENT_NAME)
+print(f"Agent deleted (name: {FOUNDRY_AGENT_NAME})")

--- a/samples/python/quickstart/create-agent/sample.yaml
+++ b/samples/python/quickstart/create-agent/sample.yaml
@@ -4,6 +4,9 @@ description: Basic quickstart sample demonstrating Microsoft Foundry agent creat
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
 live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) deletes the agent
+  # quickstart-create-agent.py creates, so a live run doesn't leave an agent
+  # behind. It runs automatically after the command below; no chaining needed here.
   command: "python quickstart-create-agent.py"
   required_env:
     - FOUNDRY_PROJECT_ENDPOINT
@@ -15,3 +18,7 @@ live_service_validation:
           env: FOUNDRY_PROJECT_ENDPOINT
         - placeholder: "gpt-5-mini"
           env: MODEL_DEPLOYMENT
+    - file: live_setup_delete_agent.py
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/typescript/quickstart/chat-with-agent/live-cleanup.sh
+++ b/samples/typescript/quickstart/chat-with-agent/live-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-detected by validate-sample.sh and run after the main live_service_validation
+# command, regardless of that command's outcome. Deletes only the agent this sample
+# created — never touches other project resources (e.g. the model deployment).
+set -e
+npm run live-cleanup:delete-agent

--- a/samples/typescript/quickstart/chat-with-agent/package.json
+++ b/samples/typescript/quickstart/chat-with-agent/package.json
@@ -7,6 +7,7 @@
   "main": "dist/quickstart-chat-with-agent.js",
   "scripts": {
     "start": "tsx --no-deprecation src/quickstart-chat-with-agent.ts",
+    "live-cleanup:delete-agent": "tsx --no-deprecation src/live-setup-delete-agent.ts",
     "build": "npx tsc"
   },
   "dependencies": {

--- a/samples/typescript/quickstart/chat-with-agent/sample.yaml
+++ b/samples/typescript/quickstart/chat-with-agent/sample.yaml
@@ -3,3 +3,19 @@ description: Basic quickstart sample demonstrating Microsoft Foundry chat with A
 
 build: "npm install --registry=https://registry.npmjs.org/"
 validate: "npx tsc --noEmit"
+live_service_validation:
+  # live-cleanup.sh (auto-detected by the harness) deletes the agent
+  # quickstart-chat-with-agent.ts creates, so a live run doesn't leave an agent
+  # behind. It runs automatically after the command below; no chaining needed here.
+  command: "npm run start"
+  required_env:
+    - FOUNDRY_PROJECT_ENDPOINT
+  substitutions:
+    - file: src/live-setup-delete-agent.ts
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT
+    - file: src/quickstart-chat-with-agent.ts
+      replacements:
+        - placeholder: "your_project_endpoint"
+          env: FOUNDRY_PROJECT_ENDPOINT

--- a/samples/typescript/quickstart/chat-with-agent/src/live-setup-delete-agent.ts
+++ b/samples/typescript/quickstart/chat-with-agent/src/live-setup-delete-agent.ts
@@ -1,0 +1,17 @@
+// Live-validation-only helper: deletes the agent created by
+// quickstart-chat-with-agent.ts so repeated live-validation runs don't accumulate
+// agent versions. Not part of the documented quickstart narrative.
+import { DefaultAzureCredential } from "@azure/identity";
+import { AIProjectClient } from "@azure/ai-projects";
+
+// Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
+const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
+const FOUNDRY_AGENT_NAME = "your-agent-name";
+
+async function main(): Promise<void> {
+    const project = new AIProjectClient(FOUNDRY_PROJECT_ENDPOINT, new DefaultAzureCredential());
+    await project.agents.delete(FOUNDRY_AGENT_NAME);
+    console.log(`Agent deleted (name: ${FOUNDRY_AGENT_NAME})`);
+}
+
+main().catch(console.error);

--- a/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
+++ b/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
@@ -3,11 +3,19 @@ import { AIProjectClient } from "@azure/ai-projects";
 
 // Format: "https://resource_name.services.ai.azure.com/api/projects/project_name"
 const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
-const FOUNDRY_AGENT_NAME = "your_agent_name";
+const FOUNDRY_AGENT_NAME = "your-agent-name";
 
 async function main(): Promise<void> {
     // Create project and openai clients to call Foundry API
     const project = new AIProjectClient(FOUNDRY_PROJECT_ENDPOINT, new DefaultAzureCredential());
+
+    // Create the agent (or a new version, if it already exists)
+    await project.agents.createVersion(FOUNDRY_AGENT_NAME, {
+        kind: "prompt",
+        model: "gpt-5-mini", //supports all Foundry direct models
+        instructions: "You are a helpful assistant that answers general questions",
+    });
+
     const openai = project.getOpenAIClient({
         azureConfig: { allowPreview: true, agentName: FOUNDRY_AGENT_NAME },
     });


### PR DESCRIPTION
## Summary

Configures the remaining quickstart samples to run **live** (against real Foundry services) instead of just build/compile validation, and closes a gap where live runs of agent-creating quickstarts left agents behind in the project.

## Changes

- **`live_service_validation` added** to all remaining eligible quickstart `sample.yaml` files (chat-with-agent, create-agent, responses across Python/C#/TypeScript/Java) so they now execute against a live Foundry project, not just compile.
- **`chat-with-agent` quickstarts are now standalone**: instead of depending on a separate create-agent step, each language's chat-with-agent script now creates its own agent inline (a few extra lines using the existing SDK), so the quickstart runs on its own.
- **Agent name is now a plain literal** (`"your-agent-name"`) instead of a `FOUNDRY_AGENT_NAME` environment variable/substitution, matching the existing convention already used in `create-agent`.
- **New `live-cleanup.sh` convention**: `validate-sample.sh` now auto-detects an optional `live-cleanup.sh` in a sample's directory and runs it right after `live_service_validation.command`, regardless of that command's pass/fail outcome. It's best-effort and never affects the validation verdict. Every quickstart that creates an agent (chat-with-agent, create-agent, all languages) now ships one, paired with a small delete-only helper script/class, so live runs clean up after themselves and don't accumulate agents in the target project.
  - Cleanup is scoped to only the agent a sample created. It never touches the project or model deployment, since those are always pre-existing resources supplied via environment variables, not created by any sample.

## Known limitation (intentionally deferred)

Cleanup today assumes a sample created exactly what its live-cleanup.sh deletes. There is no manifest tracking what a run actually created, so a future sample that conditionally creates-or-reuses a resource would not have a safe way to know what it owns. Follow-up planned to decide whether to add this tracking generically or keep the current convention.

## Verification

- All touched sample.yaml files parse as valid YAML.
- discover-validation-samples.py confirms all 10 eligible quickstart samples remain in the live-service matrix.
- Existing .github/scripts/test/test_validation_pilot.py suite (21 tests) passes unchanged.
- bash -n .github/scripts/validate-sample.sh syntax-checks clean.

## Note on CI

Per-sample live_service_validation.command (and the new cleanup step) is not executed by PR checks. validate.yml only runs build/compile validation plus one fixed generic live smoke test. The per-sample live-service run happens via the separate validation-pilot.yml workflow, which triggers on a daily schedule or manual workflow_dispatch. That workflow can be manually dispatched against this branch to exercise these changes before merge.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>